### PR TITLE
Refactor PDDL editor to use hooks for state and planning

### DIFF
--- a/Pianista-frontend/src/hooks/usePddlEditorState.ts
+++ b/Pianista-frontend/src/hooks/usePddlEditorState.ts
@@ -1,0 +1,335 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { TextAreaStatus, TextareaHandle } from "@/components/Inputbox/TextArea";
+
+import { validatePddl } from "@/api/pianista/validatePddl";
+import { validateMatchPddl } from "@/api/pianista/validateMatchPddl";
+import { generateProblemFromNL } from "@/api/pianista/generateProblem";
+import { generateDomainFromNL } from "@/api/pianista/generateDomain";
+
+import { loadPddl, savePddl as savePddlLegacy } from "@/lib/pddlStore";
+
+const DEBOUNCE_MS = 2500;
+
+export type DomainEditMode = "AI" | "D";
+export type ProblemEditMode = "AI" | "P";
+
+export type UsePddlEditorStateResult = {
+  domain: string;
+  setDomain: React.Dispatch<React.SetStateAction<string>>;
+  problem: string;
+  setProblem: React.Dispatch<React.SetStateAction<string>>;
+  domainRef: React.RefObject<TextareaHandle | null>;
+  problemRef: React.RefObject<TextareaHandle | null>;
+  domainAtEnd: boolean;
+  problemAtEnd: boolean;
+  updateDomainCaret: () => void;
+  updateProblemCaret: () => void;
+  domainMode: DomainEditMode;
+  setDomainMode: React.Dispatch<React.SetStateAction<DomainEditMode>>;
+  problemMode: ProblemEditMode;
+  setProblemMode: React.Dispatch<React.SetStateAction<ProblemEditMode>>;
+  domainStatus: TextAreaStatus;
+  setDomainStatus: React.Dispatch<React.SetStateAction<TextAreaStatus>>;
+  domainMsg: string;
+  setDomainMsg: React.Dispatch<React.SetStateAction<string>>;
+  problemStatus: TextAreaStatus;
+  setProblemStatus: React.Dispatch<React.SetStateAction<TextAreaStatus>>;
+  problemMsg: string;
+  setProblemMsg: React.Dispatch<React.SetStateAction<string>>;
+  validateDomainNow: (text: string) => Promise<void>;
+  validateProblemNow: (problemText: string, domainText: string) => Promise<void>;
+  generateDomainNow: (nlText: string) => Promise<void>;
+  generateProblemNow: (nlText: string, domainText: string) => Promise<void>;
+};
+
+export function usePddlEditorState(): UsePddlEditorStateResult {
+  const [domain, setDomain] = useState("");
+  const [problem, setProblem] = useState("");
+
+  const domainRef = useRef<TextareaHandle | null>(null);
+  const problemRef = useRef<TextareaHandle | null>(null);
+
+  const [domainAtEnd, setDomainAtEnd] = useState(true);
+  const [problemAtEnd, setProblemAtEnd] = useState(true);
+
+  const updateDomainCaret = useCallback(() => {
+    const el = domainRef.current?.textarea;
+    if (!el) return;
+    const atEnd = el.selectionStart === el.selectionEnd && el.selectionStart === el.value.length;
+    setDomainAtEnd(atEnd);
+  }, []);
+
+  const updateProblemCaret = useCallback(() => {
+    const el = problemRef.current?.textarea;
+    if (!el) return;
+    const atEnd = el.selectionStart === el.selectionEnd && el.selectionStart === el.value.length;
+    setProblemAtEnd(atEnd);
+  }, []);
+
+  const [domainMode, setDomainMode] = useState<DomainEditMode>("AI");
+  const [problemMode, setProblemMode] = useState<ProblemEditMode>("AI");
+
+  const [domainStatus, setDomainStatus] = useState<TextAreaStatus>("idle");
+  const [problemStatus, setProblemStatus] = useState<TextAreaStatus>("idle");
+  const [domainMsg, setDomainMsg] = useState("");
+  const [problemMsg, setProblemMsg] = useState("");
+
+  const domainAbort = useRef<AbortController | null>(null);
+  const problemAbort = useRef<AbortController | null>(null);
+  const domainReqId = useRef(0);
+  const problemReqId = useRef(0);
+
+  const domainDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const problemDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const validateDomainNow = useCallback(
+    async (text: string) => {
+      const d = text.trim();
+      if (!d) return;
+      if (domainDebounce.current) clearTimeout(domainDebounce.current);
+      domainAbort.current?.abort();
+      const ctrl = new AbortController();
+      domainAbort.current = ctrl;
+      const myId = ++domainReqId.current;
+      setDomainStatus("verification");
+      setDomainMsg("");
+      try {
+        const res = await validatePddl(d, "domain", ctrl.signal);
+        if (myId !== domainReqId.current) return;
+        const ok = res.result === "success";
+        setDomainStatus(ok ? "verified" : "error");
+        setDomainMsg(res.message ?? "");
+        if (ok) {
+          try {
+            if (typeof savePddlLegacy === "function") savePddlLegacy({ domain: d, problem });
+          } catch {}
+        }
+      } catch (e: any) {
+        if (myId !== domainReqId.current) return;
+        setDomainStatus("error");
+        setDomainMsg(e?.message || "Validation failed.");
+      }
+    },
+    [problem]
+  );
+
+  const validateProblemNow = useCallback(
+    async (problemText: string, domainText: string) => {
+      const p = problemText.trim();
+      if (!p) return;
+      if (problemDebounce.current) clearTimeout(problemDebounce.current);
+      problemAbort.current?.abort();
+      const ctrl = new AbortController();
+      problemAbort.current = ctrl;
+      const myId = ++problemReqId.current;
+      setProblemStatus("verification");
+      setProblemMsg("");
+      try {
+        const d = domainText.trim();
+        if (!d) {
+          const basic = await validatePddl(p, "problem", ctrl.signal);
+          if (myId !== problemReqId.current) return;
+          const ok = basic.result === "success";
+          setProblemStatus(ok ? "verified" : "error");
+          setProblemMsg(basic.message || (ok ? "Problem syntax looks valid." : "Problem validation failed."));
+          if (ok) {
+            try {
+              if (typeof savePddlLegacy === "function") savePddlLegacy({ domain, problem: p });
+            } catch {}
+          }
+          return;
+        }
+        try {
+          const match = await validateMatchPddl(d, p, ctrl.signal);
+          if (myId !== problemReqId.current) return;
+          if (match.result === "success") {
+            setProblemStatus("verified");
+            setProblemMsg(match.message || "Problem successfully validated against domain.");
+            try {
+              if (typeof savePddlLegacy === "function") savePddlLegacy({ domain: d, problem: p });
+            } catch {}
+            return;
+          }
+        } catch {
+          // fall through
+        }
+        const basic = await validatePddl(p, "problem", ctrl.signal);
+        if (myId !== problemReqId.current) return;
+        if (basic.result === "success") {
+          setProblemStatus("error");
+          setProblemMsg("Syntax OK, but the problem does not match the current domain.");
+        } else {
+          setProblemStatus("error");
+          setProblemMsg(basic.message || "Problem validation failed.");
+        }
+      } catch (e: any) {
+        if (myId !== problemReqId.current) return;
+        setProblemStatus("error");
+        setProblemMsg(e?.message || "Validation failed.");
+      }
+    },
+    [domain]
+  );
+
+  const generateProblemNow = useCallback(
+    async (nlText: string, domainText: string) => {
+      const t = nlText.trim();
+      const d = domainText.trim();
+      if (!t) return;
+      if (!d) {
+        setProblemStatus("error");
+        setProblemMsg("Add a domain to generate a problem from natural language.");
+        return;
+      }
+      if (problemDebounce.current) clearTimeout(problemDebounce.current);
+      problemAbort.current?.abort();
+      const ctrl = new AbortController();
+      problemAbort.current = ctrl;
+      const myId = ++problemReqId.current;
+      setProblemStatus("verification");
+      setProblemMsg("");
+      try {
+        const res = await generateProblemFromNL(t, d, {
+          attempts: 1,
+          generate_both: false,
+          signal: ctrl.signal,
+        });
+        if (myId !== problemReqId.current) return;
+        if (res.result_status === "success" && res.generated_problem) {
+          const generated = res.generated_problem.trim();
+          setProblem(generated);
+          await validateProblemNow(generated, d);
+        } else {
+          setProblemStatus("error");
+          setProblemMsg(res.message || "Could not generate a problem from the provided description.");
+        }
+      } catch (e: any) {
+        if (myId !== problemReqId.current) return;
+        setProblemStatus("error");
+        setProblemMsg(e?.message || "Problem generation failed.");
+      }
+    },
+    [validateProblemNow]
+  );
+
+  const generateDomainNow = useCallback(
+    async (nlText: string) => {
+      const t = nlText.trim();
+      if (!t) return;
+      if (domainDebounce.current) clearTimeout(domainDebounce.current);
+      domainAbort.current?.abort();
+      const ctrl = new AbortController();
+      domainAbort.current = ctrl;
+      const myId = ++domainReqId.current;
+      setDomainStatus("verification");
+      setDomainMsg("");
+      try {
+        const res = await generateDomainFromNL(t, { attempts: 1, generate_both: false, signal: ctrl.signal });
+        if (myId !== domainReqId.current) return;
+        if (res.result_status === "success" && res.generated_domain) {
+          const generated = res.generated_domain.trim();
+          setDomain(generated);
+          await validateDomainNow(generated);
+          if (problem.trim()) await validateProblemNow(problem, generated);
+        } else {
+          setDomainStatus("error");
+          setDomainMsg(res.message || "Could not generate a domain from the provided description.");
+        }
+      } catch (e: any) {
+        if (myId !== domainReqId.current) return;
+        setDomainStatus("error");
+        setDomainMsg(e?.message || "Domain generation failed.");
+      }
+    },
+    [problem, validateDomainNow, validateProblemNow]
+  );
+
+  useEffect(() => {
+    const saved = loadPddl();
+    if (!saved) return;
+    const d = (saved.domain ?? "").trim();
+    const p = (saved.problem ?? "").trim();
+    if (d) setDomain(d);
+    if (p) setProblem(p);
+    if (d || p) {
+      setTimeout(async () => {
+        if (d) await validateDomainNow(d);
+        if (p) await validateProblemNow(p, d);
+      }, 0);
+    }
+  }, [validateDomainNow, validateProblemNow]);
+
+  useEffect(() => {
+    const empty = !domain.trim();
+    if (empty) {
+      if (domainDebounce.current) clearTimeout(domainDebounce.current);
+      domainAbort.current?.abort();
+      setDomainStatus("idle");
+      setDomainMsg("");
+      return;
+    }
+    if (domainMode === "AI") return;
+    if (domainDebounce.current) clearTimeout(domainDebounce.current);
+    domainDebounce.current = setTimeout(() => validateDomainNow(domain), DEBOUNCE_MS);
+    return () => {
+      if (domainDebounce.current) clearTimeout(domainDebounce.current);
+    };
+  }, [domain, domainMode, validateDomainNow]);
+
+  useEffect(() => {
+    const empty = !problem.trim();
+    if (empty) {
+      if (problemDebounce.current) clearTimeout(problemDebounce.current);
+      problemAbort.current?.abort();
+      setProblemStatus("idle");
+      setProblemMsg("");
+      return;
+    }
+    if (problemMode === "AI") return;
+    if (problemDebounce.current) clearTimeout(problemDebounce.current);
+    problemDebounce.current = setTimeout(() => validateProblemNow(problem, domain), DEBOUNCE_MS);
+    return () => {
+      if (problemDebounce.current) clearTimeout(problemDebounce.current);
+    };
+  }, [problem, domain, problemMode, validateProblemNow]);
+
+  useEffect(() => {
+    return () => {
+      domainAbort.current?.abort();
+      problemAbort.current?.abort();
+      if (domainDebounce.current) clearTimeout(domainDebounce.current);
+      if (problemDebounce.current) clearTimeout(problemDebounce.current);
+    };
+  }, []);
+
+  return {
+    domain,
+    setDomain,
+    problem,
+    setProblem,
+    domainRef,
+    problemRef,
+    domainAtEnd,
+    problemAtEnd,
+    updateDomainCaret,
+    updateProblemCaret,
+    domainMode,
+    setDomainMode,
+    problemMode,
+    setProblemMode,
+    domainStatus,
+    setDomainStatus,
+    domainMsg,
+    setDomainMsg,
+    problemStatus,
+    setProblemStatus,
+    problemMsg,
+    setProblemMsg,
+    validateDomainNow,
+    validateProblemNow,
+    generateDomainNow,
+    generateProblemNow,
+  };
+}
+

--- a/Pianista-frontend/src/hooks/usePlanGeneration.ts
+++ b/Pianista-frontend/src/hooks/usePlanGeneration.ts
@@ -1,0 +1,299 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { NavigateFunction } from "react-router-dom";
+
+import type { TextAreaStatus } from "@/components/Inputbox/TextArea";
+
+import { validatePddl } from "@/api/pianista/validatePddl";
+import { validateMatchPddl } from "@/api/pianista/validateMatchPddl";
+import { generateProblemFromNL } from "@/api/pianista/generateProblem";
+import { generateDomainFromNL } from "@/api/pianista/generateDomain";
+import { generatePlan } from "@/api/pianista/generatePlan";
+import { getPlan } from "@/api/pianista/getPlan";
+
+import {
+  savePddl as savePddlLegacy,
+  savePddlSnapshot,
+  savePlanJob,
+  loadPlan,
+  savePlanResult,
+} from "@/lib/pddlStore";
+
+export type PlanPhase = "idle" | "submitting" | "polling" | "success" | "error";
+
+type UsePlanGenerationArgs = {
+  domain: string;
+  problem: string;
+  setDomain: React.Dispatch<React.SetStateAction<string>>;
+  setProblem: React.Dispatch<React.SetStateAction<string>>;
+  setDomainStatus: React.Dispatch<React.SetStateAction<TextAreaStatus>>;
+  setDomainMsg: React.Dispatch<React.SetStateAction<string>>;
+  setProblemStatus: React.Dispatch<React.SetStateAction<TextAreaStatus>>;
+  setProblemMsg: React.Dispatch<React.SetStateAction<string>>;
+  navigate: NavigateFunction;
+  jobFromUrl: string;
+};
+
+type EnsureResult = Promise<{ ok: boolean; text: string }>;
+
+export type UsePlanGenerationResult = {
+  planPhase: PlanPhase;
+  genLabel: string;
+  planId: string;
+  planError: string;
+  selectedPlanner: string;
+  setSelectedPlanner: React.Dispatch<React.SetStateAction<string>>;
+  ensureValidDomain: (dText: string) => EnsureResult;
+  ensureValidProblem: (pText: string, dText: string) => EnsureResult;
+  handleGeneratePlan: () => Promise<void>;
+  handleRegenerate: () => void;
+};
+
+const SELECTED_PLANNER_KEY = "pddl.selectedPlanner";
+
+export function usePlanGeneration({
+  domain,
+  problem,
+  setDomain,
+  setProblem,
+  setDomainStatus,
+  setDomainMsg,
+  setProblemStatus,
+  setProblemMsg,
+  navigate,
+  jobFromUrl,
+}: UsePlanGenerationArgs): UsePlanGenerationResult {
+  const [planPhase, setPlanPhase] = useState<PlanPhase>("idle");
+  const [genLabel, setGenLabel] = useState<string>("Generate Plan");
+  const [planId, setPlanId] = useState<string>("");
+  const [planError, setPlanError] = useState<string>("");
+
+  const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollAbort = useRef<AbortController | null>(null);
+
+  const [selectedPlanner, setSelectedPlanner] = useState<string>(() => {
+    try {
+      return localStorage.getItem(SELECTED_PLANNER_KEY) || "auto";
+    } catch {
+      return "auto";
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(SELECTED_PLANNER_KEY, selectedPlanner);
+    } catch {}
+  }, [selectedPlanner]);
+
+  useEffect(() => {
+    if (!jobFromUrl) return;
+    const rec = loadPlan(jobFromUrl);
+    if (!rec) return;
+    setPlanId(jobFromUrl);
+    if (rec.domain) setDomain(rec.domain);
+    if (rec.problem) setProblem(rec.problem);
+    if (rec.plan) setPlanPhase("success");
+  }, [jobFromUrl, setDomain, setProblem]);
+
+  useEffect(() => {
+    return () => {
+      if (pollTimer.current) clearInterval(pollTimer.current);
+      pollAbort.current?.abort();
+    };
+  }, []);
+
+  const startPolling = useCallback(
+    (id: string) => {
+      if (pollTimer.current) clearInterval(pollTimer.current);
+      pollAbort.current?.abort();
+      setPlanId(id);
+      setPlanPhase("polling");
+      setPlanError("");
+      pollTimer.current = setInterval(async () => {
+        const ctrl = new AbortController();
+        pollAbort.current = ctrl;
+        try {
+          const res: any = await getPlan(id, ctrl.signal);
+          const status = String(res?.status ?? res?.result_status ?? "").toLowerCase();
+          if (status === "success") {
+            clearInterval(pollTimer.current!);
+            pollTimer.current = null;
+            setPlanPhase("success");
+            const planText = (res?.plan ?? res?.result_plan ?? "").trim?.() ?? "";
+            if (planText) {
+              try {
+                savePlanResult(id, planText);
+              } catch {}
+            }
+            setTimeout(() => {
+              navigate(`/plan?job=${encodeURIComponent(id)}`, { replace: true });
+            }, 0);
+            return;
+          }
+          if (status === "failure") {
+            clearInterval(pollTimer.current!);
+            pollTimer.current = null;
+            setPlanPhase("error");
+            setPlanError(res?.message || "Planning failed.");
+            return;
+          }
+        } catch {
+          /* keep polling */
+        }
+      }, 2500);
+    },
+    [navigate]
+  );
+
+  const ensureValidDomain = useCallback(
+    async (dText: string) => {
+      const d = dText.trim();
+      if (!d) return { ok: false, text: "" };
+      setGenLabel("Validating…");
+      setDomainStatus("verification");
+      try {
+        const res = await validatePddl(d, "domain");
+        if (res.result === "success") {
+          setDomainStatus("verified");
+          setDomainMsg(res.message ?? "");
+          return { ok: true, text: d };
+        }
+        setGenLabel("Fixing…");
+        const ai = await generateDomainFromNL(d, { attempts: 1, generate_both: false });
+        if (ai.result_status === "success" && ai.generated_domain) {
+          const fixed = ai.generated_domain.trim();
+          setDomain(fixed);
+          const re = await validatePddl(fixed, "domain");
+          const ok = re.result === "success";
+          setDomainStatus(ok ? "verified" : "error");
+          setDomainMsg(re.message ?? (ok ? "" : "Domain still invalid after AI repair."));
+          return { ok, text: fixed };
+        }
+        setDomainStatus("error");
+        setDomainMsg(res.message || "Domain invalid, and AI repair failed.");
+        return { ok: false, text: d };
+      } catch (e: any) {
+        setDomainStatus("error");
+        setDomainMsg(e?.message || "Domain validation failed.");
+        return { ok: false, text: d };
+      }
+    },
+    [setDomain, setDomainMsg, setDomainStatus]
+  );
+
+  const ensureValidProblem = useCallback(
+    async (pText: string, dText: string) => {
+      const p = pText.trim();
+      const d = dText.trim();
+      if (!p) return { ok: false, text: "" };
+      setGenLabel("Validating…");
+      setProblemStatus("verification");
+      try {
+        if (d) {
+          try {
+            const match = await validateMatchPddl(d, p);
+            if (match.result === "success") {
+              setProblemStatus("verified");
+              setProblemMsg(match.message ?? "");
+              return { ok: true, text: p };
+            }
+          } catch {
+            /* fall through */
+          }
+        }
+        const basic = await validatePddl(p, "problem");
+        if (basic.result === "success" && d) {
+          setProblemStatus("error");
+          setProblemMsg("Syntax OK, but the problem does not match the current domain.");
+          return { ok: false, text: p };
+        }
+        if (basic.result === "success") {
+          setProblemStatus("verified");
+          setProblemMsg(basic.message ?? "");
+          return { ok: true, text: p };
+        }
+        setGenLabel("Fixing…");
+        const ai = await generateProblemFromNL(p, d || "", { attempts: 1, generate_both: false });
+        if (ai.result_status === "success" && ai.generated_problem) {
+          const fixed = ai.generated_problem.trim();
+          setProblem(fixed);
+          if (d) {
+            const match2 = await validateMatchPddl(d, fixed);
+            const ok = match2.result === "success";
+            setProblemStatus(ok ? "verified" : "error");
+            setProblemMsg(match2.message ?? (ok ? "" : "Problem still mismatched after AI repair."));
+            return { ok, text: fixed };
+          }
+          const basic2 = await validatePddl(fixed, "problem");
+          const ok = basic2.result === "success";
+          setProblemStatus(ok ? "verified" : "error");
+          setProblemMsg(basic2.message ?? (ok ? "" : "Problem still invalid after AI repair."));
+          return { ok, text: fixed };
+        }
+        setProblemStatus("error");
+        setProblemMsg(basic.message || "Problem invalid, and AI repair failed.");
+        return { ok: false, text: p };
+      } catch (e: any) {
+        setProblemStatus("error");
+        setProblemMsg(e?.message || "Problem validation failed.");
+        return { ok: false, text: p };
+      }
+    },
+    [setProblem, setProblemMsg, setProblemStatus]
+  );
+
+  const handleGeneratePlan = useCallback(async () => {
+    const canGenerate = !!domain.trim() && !!problem.trim();
+    if (!canGenerate || planPhase === "submitting" || planPhase === "polling") return;
+    setPlanPhase("submitting");
+    setPlanError("");
+    try {
+      const dom = await ensureValidDomain(domain);
+      const prob = await ensureValidProblem(problem, dom.text);
+      if (!dom.ok || !prob.ok) {
+        setPlanPhase("error");
+        setPlanError("Inputs are invalid even after AI repair.");
+        setGenLabel("Generate Plan");
+        return;
+      }
+      const d = dom.text.trim();
+      const p = prob.text.trim();
+      setGenLabel("Generating…");
+      savePddlSnapshot(d, p);
+      if (typeof savePddlLegacy === "function") savePddlLegacy({ domain: d, problem: p });
+      const opts: any = { convert_real_types: true };
+      if (selectedPlanner && selectedPlanner !== "auto") {
+        opts.planner = selectedPlanner;
+      }
+      const { id } = await generatePlan(d, p, opts);
+      savePlanJob(id, d, p);
+      startPolling(id);
+    } catch (e: any) {
+      setPlanPhase("error");
+      setPlanError(e?.message || "Failed to start planning.");
+    }
+  }, [domain, ensureValidDomain, ensureValidProblem, planPhase, problem, selectedPlanner, startPolling]);
+
+  const handleRegenerate = useCallback(() => {
+    if (pollTimer.current) clearInterval(pollTimer.current);
+    pollAbort.current?.abort();
+    setPlanId("");
+    setPlanError("");
+    setPlanPhase("idle");
+    setGenLabel("Generate Plan");
+    navigate("/pddl-edit", { replace: true });
+  }, [navigate]);
+
+  return {
+    planPhase,
+    genLabel,
+    planId,
+    planError,
+    selectedPlanner,
+    setSelectedPlanner,
+    ensureValidDomain,
+    ensureValidProblem,
+    handleGeneratePlan,
+    handleRegenerate,
+  };
+}
+


### PR DESCRIPTION
## Summary
- extract the domain/problem editor state, caret tracking, and validation/generation helpers into a new `usePddlEditorState` hook
- add a `usePlanGeneration` hook to manage planner selection, validation/repair, submission, and polling
- refactor the PDDL edit page to consume the new hooks without altering the UI or behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d80028b598832f969f1fad8a9e4114