### PR TITLE
Refactor Mermaid preview into reusable hook

### DIFF
--- a/Pianista-frontend/src/hooks/useMermaidPreview.ts
+++ b/Pianista-frontend/src/hooks/useMermaidPreview.ts
@@ -1,0 +1,284 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { generateMermaid, type MermaidMode } from "@/api/pianista/generateMermaid";
+import type { TextAreaStatus } from "@/components/Inputbox/TextArea";
+
+export type MermaidUiMode = "D+P" | "D" | "P";
+
+function djb2(s: string) {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h) ^ s.charCodeAt(i);
+  return (h >>> 0).toString(36);
+}
+
+function inputFor(mode: MermaidUiMode, d: string, p: string) {
+  return mode === "D" ? d : mode === "P" ? p : `${d}\n${p}`;
+}
+
+function cacheKey(mode: MermaidUiMode, d: string, p: string) {
+  return `mermaid_cache:${mode}:${djb2(inputFor(mode, d, p))}`;
+}
+
+function readMermaidCache(mode: MermaidUiMode, d: string, p: string) {
+  try {
+    return localStorage.getItem(cacheKey(mode, d, p)) || "";
+  } catch {
+    return "";
+  }
+}
+
+function writeMermaidCache(mode: MermaidUiMode, d: string, p: string, mermaid: string) {
+  try {
+    localStorage.setItem(cacheKey(mode, d, p), mermaid);
+  } catch {
+    // noop — cache failures aren't critical
+  }
+}
+
+function persistRawMermaid(mode: MermaidUiMode, d: string, p: string, text: string) {
+  writeMermaidCache(mode, d.trim(), p.trim(), text);
+}
+
+function fixProblemEdges(src: string) {
+  let out = src;
+
+  const ensureGoalNode = (text: string) => {
+    if (/\bgoal\(\(/i.test(text)) return text;
+    const lines = text.split(/\r?\n/);
+    const problemIdx = lines.findIndex((l) => /subgraph\s+problem\b/i.test(l));
+    const graphIdx = lines.findIndex((l) => /^\s*graph\b/i.test(l));
+    const def = "  goal((goal))";
+    if (problemIdx >= 0) lines.splice(problemIdx + 1, 0, def);
+    else if (graphIdx >= 0) lines.splice(graphIdx + 1, 0, def);
+    else lines.unshift(def);
+    return lines.join("\n");
+  };
+
+  out = out.replace(
+    /^(\s*[A-Za-z][\w-]*)\s*([-=]{2,}(?:>|)?)\s*\|[^|]*\|\s*$/gm,
+    (_m, lhs, edge) => `${lhs} ${edge} goal`
+  );
+
+  out = out.replace(
+    /(\s*[A-Za-z][\w-]*)\s*([-=]{2,}(?:>|)?)\s*\|[^|]*\|\s*(?=\s+[A-Za-z][\w-]*\s*(?:[-=]{2,}(?:>|)?|-->|==>))/g,
+    (_m, lhs, edge) => `${lhs} ${edge} goal `
+  );
+
+  out = out.replace(
+    /^(\s*[A-Za-z][\w-]*)\s*([-=]{2,}(?:>|)?)\s*\|\s*$/gm,
+    (_m, lhs, edge) => `${lhs} ${edge} goal`
+  );
+
+  if (/[\s-](goal)(?!\s*\(\()/i.test(out)) {
+    out = ensureGoalNode(out);
+  }
+  return out;
+}
+
+function maybeFixMermaid(mode: MermaidUiMode, text: string) {
+  return mode === "P" ? fixProblemEdges(text) : text;
+}
+
+function isAbortError(error: unknown): error is { name?: string } {
+  return typeof error === "object" && error !== null && "name" in error && (error as { name?: string }).name === "AbortError";
+}
+
+function toApiMode(m: MermaidUiMode): MermaidMode {
+  return m === "D" ? "domain" : m === "P" ? "problem" : "none";
+}
+
+export function useMermaidPreview({
+  domain,
+  problem,
+}: {
+  domain: string;
+  problem: string;
+}) {
+  const [isMermaidOpen, setIsMermaidOpen] = useState(false);
+  const [mermaidText, setMermaidText] = useState("");
+  const [mermaidStatus, setMermaidStatus] = useState<TextAreaStatus>("idle");
+  const [mermaidUiMode, setMermaidUiMode] = useState<MermaidUiMode>("D+P");
+
+  const mermaidAbort = useRef<AbortController | null>(null);
+  const mermaidReqSeq = useRef(0);
+  const lastMermaidKey = useRef<string>("");
+  const mermaidAutoDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestMermaidText = useRef("");
+
+  useEffect(() => {
+    latestMermaidText.current = mermaidText;
+  }, [mermaidText]);
+
+  const cleanup = useCallback(() => {
+    mermaidAbort.current?.abort();
+    if (mermaidAutoDebounce.current) {
+      clearTimeout(mermaidAutoDebounce.current);
+      mermaidAutoDebounce.current = null;
+    }
+  }, []);
+
+  useEffect(() => cleanup, [cleanup]);
+
+  const trimmedDomain = useMemo(() => domain.trim(), [domain]);
+  const trimmedProblem = useMemo(() => problem.trim(), [problem]);
+
+  const canConvertMermaid = useMemo(() => {
+    const dOk = !!trimmedDomain;
+    const pOk = !!trimmedProblem;
+    if (mermaidUiMode === "D") return dOk;
+    if (mermaidUiMode === "P") return pOk;
+    return dOk && pOk;
+  }, [trimmedDomain, trimmedProblem, mermaidUiMode]);
+
+  const fetchMermaidInternal = useCallback(
+    async (mode: MermaidUiMode, force = false) => {
+      const d = trimmedDomain;
+      const p = trimmedProblem;
+      const needed = mode === "D" ? !!d : mode === "P" ? !!p : !!(d && p);
+      if (!needed) return;
+
+      const key = cacheKey(mode, d, p);
+
+      if (!force && lastMermaidKey.current === key && latestMermaidText.current) {
+        setMermaidStatus("verified");
+        return;
+      }
+
+      if (!force) {
+        const cached = readMermaidCache(mode, d, p);
+        if (cached) {
+          setMermaidText(cached);
+          setMermaidStatus("verified");
+          lastMermaidKey.current = key;
+          return;
+        }
+      }
+
+      mermaidAbort.current?.abort();
+      const ctrl = new AbortController();
+      mermaidAbort.current = ctrl;
+      const myId = ++mermaidReqSeq.current;
+
+      setMermaidStatus("ai-thinking");
+
+      try {
+        const res = await generateMermaid(toApiMode(mode), d, p, "", ctrl.signal);
+        if (myId !== mermaidReqSeq.current) return;
+        if (res.result_status === "success" && res.mermaid) {
+          let out = res.mermaid.trim();
+          out = maybeFixMermaid(mode, out);
+          setMermaidText(out);
+          setMermaidStatus("verified");
+          writeMermaidCache(mode, d, p, out);
+          lastMermaidKey.current = key;
+        } else {
+          setMermaidStatus("error");
+          setMermaidText(
+            `%% Mermaid conversion failed${res.message ? `: ${res.message}` : ""}\nflowchart TD\n  A[Start] --> B[Check endpoint/mode/key];`
+          );
+        }
+      } catch (error) {
+        if (isAbortError(error)) return;
+        if (myId !== mermaidReqSeq.current) return;
+        setMermaidStatus("error");
+        setMermaidText(`%% Network error\nflowchart TD\n  A[Start] --> B[Retry request];`);
+      }
+    },
+    [trimmedDomain, trimmedProblem]
+  );
+
+  const fetchMermaid = useCallback(
+    (force = false) => fetchMermaidInternal(mermaidUiMode, force),
+    [fetchMermaidInternal, mermaidUiMode]
+  );
+
+  useEffect(() => {
+    if (!isMermaidOpen) return;
+    if (!canConvertMermaid) return;
+
+    if (mermaidAutoDebounce.current) clearTimeout(mermaidAutoDebounce.current);
+    setMermaidStatus("ai-thinking");
+    mermaidAutoDebounce.current = setTimeout(() => {
+      fetchMermaidInternal(mermaidUiMode, true);
+    }, 300);
+
+    return () => {
+      if (mermaidAutoDebounce.current) {
+        clearTimeout(mermaidAutoDebounce.current);
+        mermaidAutoDebounce.current = null;
+      }
+    };
+  }, [trimmedDomain, trimmedProblem, isMermaidOpen, canConvertMermaid, fetchMermaidInternal, mermaidUiMode]);
+
+  useEffect(() => {
+    if (!isMermaidOpen) return;
+    const d = trimmedDomain;
+    const p = trimmedProblem;
+    const needed = mermaidUiMode === "D" ? !!d : mermaidUiMode === "P" ? !!p : !!(d && p);
+    if (!needed) return;
+
+    const key = cacheKey(mermaidUiMode, d, p);
+
+    if (lastMermaidKey.current === key && latestMermaidText.current) {
+      setMermaidStatus("verified");
+      return;
+    }
+
+    const cached = readMermaidCache(mermaidUiMode, d, p);
+    if (cached) {
+      setMermaidText(cached);
+      setMermaidStatus("verified");
+      lastMermaidKey.current = key;
+      return;
+    }
+
+    setMermaidStatus("ai-thinking");
+    fetchMermaidInternal(mermaidUiMode, true);
+  }, [mermaidUiMode, isMermaidOpen, trimmedDomain, trimmedProblem, fetchMermaidInternal]);
+
+  const openMermaid = useCallback(() => {
+    if (!canConvertMermaid) return;
+    setIsMermaidOpen(true);
+    const d = trimmedDomain;
+    const p = trimmedProblem;
+    const key = cacheKey(mermaidUiMode, d, p);
+    const cached = readMermaidCache(mermaidUiMode, d, p);
+    if (cached) {
+      setMermaidText(cached);
+      setMermaidStatus("verified");
+      lastMermaidKey.current = key;
+    } else {
+      setMermaidStatus("ai-thinking");
+      fetchMermaidInternal(mermaidUiMode, true);
+    }
+  }, [canConvertMermaid, trimmedDomain, trimmedProblem, mermaidUiMode, fetchMermaidInternal]);
+
+  const closeMermaid = useCallback(() => {
+    setIsMermaidOpen(false);
+    setMermaidStatus("idle");
+    cleanup();
+  }, [cleanup]);
+
+  const onMermaidTextChange = useCallback(
+    (next: string) => {
+      setMermaidText(next);
+      persistRawMermaid(mermaidUiMode, domain, problem, next);
+      lastMermaidKey.current = cacheKey(mermaidUiMode, trimmedDomain, trimmedProblem);
+      setMermaidStatus("verified");
+    },
+    [domain, problem, mermaidUiMode, trimmedDomain, trimmedProblem]
+  );
+
+  return {
+    isMermaidOpen,
+    openMermaid,
+    closeMermaid,
+    mermaidText,
+    mermaidStatus,
+    mermaidUiMode,
+    setMermaidUiMode,
+    canConvertMermaid,
+    onMermaidTextChange,
+    fetchMermaid,
+  };
+}

--- a/Pianista-frontend/src/pages/pddl-edit.tsx
+++ b/Pianista-frontend/src/pages/pddl-edit.tsx
@@ -1,16 +1,12 @@
 // src/pages/pddl-edit.tsx
-import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 
 import BrandLogo from "@/components/VS_BrandButton";
 import PillButton from "@/components/PillButton";
-import { type TextAreaStatus } from "@/components/Inputbox/TextArea";
 import ModeSlider from "@/components/Inputbox/Controls/ModeSlider";
 import MermaidPanel from "@/components/MermaidPanel";
 import PlannerDropup from "../components/PlannerDropup";
 import EditorPanel from "@/components/pddl/EditorPanel";
-
-import { generateMermaid, type MermaidMode } from "@/api/pianista/generateMermaid";
 
 import Spinner from "@/components/icons/Spinner";
 import Brain from "@/components/icons/Brain";
@@ -24,86 +20,7 @@ import {
   type ProblemEditMode,
 } from "@/hooks/usePddlEditorState";
 import { usePlanGeneration } from "@/hooks/usePlanGeneration";
-
-
-type MermaidUiMode = "D+P" | "D" | "P";
-
-/* ----------------------------- Cache utilities ----------------------------- */
-
-function djb2(s: string) {
-  let h = 5381;
-  for (let i = 0; i < s.length; i++) h = ((h << 5) + h) ^ s.charCodeAt(i);
-  return (h >>> 0).toString(36);
-}
-function inputFor(mode: MermaidUiMode, d: string, p: string) {
-  const dt = d.trim(),
-    pt = p.trim();
-  return mode === "D" ? dt : mode === "P" ? pt : `${dt}\n${pt}`;
-}
-function cacheKey(mode: MermaidUiMode, d: string, p: string) {
-  return `mermaid_cache:${mode}:${djb2(inputFor(mode, d, p))}`;
-}
-function readMermaidCache(mode: MermaidUiMode, d: string, p: string) {
-  try {
-    return localStorage.getItem(cacheKey(mode, d, p)) || "";
-  } catch {
-    return "";
-  }
-}
-function writeMermaidCache(mode: MermaidUiMode, d: string, p: string, mermaid: string) {
-  try {
-    localStorage.setItem(cacheKey(mode, d, p), mermaid);
-  } catch {}
-}
-function persistRawMermaid(mode: MermaidUiMode, d: string, p: string, text: string) {
-  writeMermaidCache(mode, d.trim(), p.trim(), text);
-}
-
-/* ---------- Fix stray labels (|...|) in Problem-only diagrams if present --- */
-
-function fixProblemEdges(src: string) {
-  let out = src;
-
-  const ensureGoalNode = (text: string) => {
-    if (/\bgoal\(\(/i.test(text)) return text; // goal((goal)) exists
-    const lines = text.split(/\r?\n/);
-    const problemIdx = lines.findIndex((l) => /subgraph\s+problem\b/i.test(l));
-    const graphIdx = lines.findIndex((l) => /^\s*graph\b/i.test(l));
-    const def = "  goal((goal))";
-    if (problemIdx >= 0) lines.splice(problemIdx + 1, 0, def);
-    else if (graphIdx >= 0) lines.splice(graphIdx + 1, 0, def);
-    else lines.unshift(def);
-    return lines.join("\n");
-  };
-
-  // Orphan at end-of-line: <lhs> <edge> |label| $
-  out = out.replace(
-    /^(\s*[A-Za-z][\w-]*)\s*([-=]{2,}(?:>|)?)\s*\|[^|]*\|\s*$/gm,
-    (_m, lhs, edge) => `${lhs} ${edge} goal`
-  );
-
-  // Orphan before another chain on SAME line: <lhs> <edge> |label|   <next>
-  out = out.replace(
-    /(\s*[A-Za-z][\w-]*)\s*([-=]{2,}(?:>|)?)\s*\|[^|]*\|\s*(?=\s+[A-Za-z][\w-]*\s*(?:[-=]{2,}(?:>|)?|-->|==>))/g,
-    (_m, lhs, edge) => `${lhs} ${edge} goal `
-  );
-
-  // Super-stray "pipe only" endings like "... --- |"
-  out = out.replace(
-    /^(\s*[A-Za-z][\w-]*)\s*([-=]{2,}(?:>|)?)\s*\|\s*$/gm,
-    (_m, lhs, edge) => `${lhs} ${edge} goal`
-  );
-
-  if (/[\s-](goal)(?!\s*\(\()/i.test(out)) {
-    out = ensureGoalNode(out);
-  }
-  return out;
-}
-function maybeFixMermaid(mode: MermaidUiMode, text: string) {
-  return mode === "P" ? fixProblemEdges(text) : text;
-}
-
-/* -------------------------------------------------------------------------- */
+import { useMermaidPreview, type MermaidUiMode } from "@/hooks/useMermaidPreview";
 
 export default function PddlEditPage() {
   const [params] = useSearchParams();
@@ -156,24 +73,6 @@ export default function PddlEditPage() {
   const { planPhase, genLabel, planId, selectedPlanner, setSelectedPlanner, handleGeneratePlan, handleRegenerate } =
     plan;
 
-  /* --------------------------- Mermaid container -------------------------- */
-  const [showMermaid, setShowMermaid] = useState(false);
-  const [mermaidText, setMermaidText] = useState("");
-  const [mermaidStatus, setMermaidStatus] = useState<TextAreaStatus>("idle");
-  const [mermaidUiMode, setMermaidUiMode] = useState<MermaidUiMode>("D+P");
-
-  const mermaidAbort = useRef<AbortController | null>(null);
-  const mermaidReqSeq = useRef(0);
-  const lastMermaidKey = useRef<string>("");
-  const mermaidAutoDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      mermaidAbort.current?.abort();
-      if (mermaidAutoDebounce.current) clearTimeout(mermaidAutoDebounce.current);
-    };
-  }, []);
-
   /* ------------------------- Auto-detect AI/D/P modes ---------------------- */
   useTwoModeAutoDetect({
     kind: "domain",
@@ -197,124 +96,20 @@ export default function PddlEditPage() {
   });
 
   /* ----------------------------- Readiness flags --------------------------- */
+  const {
+    isMermaidOpen,
+    openMermaid,
+    closeMermaid,
+    mermaidText,
+    mermaidStatus,
+    mermaidUiMode,
+    setMermaidUiMode,
+    canConvertMermaid,
+    onMermaidTextChange,
+    fetchMermaid,
+  } = useMermaidPreview({ domain, problem });
+
   const canGenerate = !!domain.trim() && !!problem.trim();
-  const canConvertMermaid = useMemo(() => {
-    const dOk = !!domain.trim();
-    const pOk = !!problem.trim();
-    if (mermaidUiMode === "D") return dOk;
-    if (mermaidUiMode === "P") return pOk;
-    return dOk && pOk; // D+P
-  }, [domain, problem, mermaidUiMode]);
-
-  const toApiMode = (m: MermaidUiMode): MermaidMode =>
-    m === "D" ? "domain" : m === "P" ? "problem" : "none";
-
-  /* -------------------- Auto-refresh Mermaid on D/P edits ------------------- */
-  useEffect(() => {
-    if (!showMermaid) return;
-    if (!canConvertMermaid) return;
-
-    if (mermaidAutoDebounce.current) clearTimeout(mermaidAutoDebounce.current);
-    setMermaidStatus("ai-thinking"); // triggers overlay + glow
-    mermaidAutoDebounce.current = setTimeout(() => {
-      fetchMermaidFor(mermaidUiMode, /* force */ true);
-    }, 300);
-
-    return () => {
-      if (mermaidAutoDebounce.current) clearTimeout(mermaidAutoDebounce.current);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [domain, problem, showMermaid]); // listens to D/P edits
-
-  /* ------------------------ Cache-first on mode switch ---------------------- */
-  useEffect(() => {
-    const d = domain.trim();
-    const p = problem.trim();
-    if (!showMermaid) return;
-    const needed = mermaidUiMode === "D" ? !!d : mermaidUiMode === "P" ? !!p : !!(d && p);
-    if (!needed) return;
-
-    const key = cacheKey(mermaidUiMode, d, p);
-
-    // If already rendered this exact key, don't do anything
-    if (lastMermaidKey.current === key && mermaidText) {
-      setMermaidStatus("verified");
-      return;
-    }
-
-    // Try cache first
-    const cached = readMermaidCache(mermaidUiMode, d, p);
-    if (cached) {
-      setMermaidText(cached);
-      setMermaidStatus("verified");
-      lastMermaidKey.current = key;
-      return;
-    }
-
-    // No cache -> fetch
-    setMermaidStatus("ai-thinking");
-    fetchMermaidFor(mermaidUiMode, /* force */ true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mermaidUiMode, showMermaid]);
-
-  /* -------------------------- Mermaid fetch (gated) ------------------------- */
-
-  const fetchMermaidFor = async (mode: MermaidUiMode, force = false) => {
-    const d = domain.trim();
-    const p = problem.trim();
-    const needed = mode === "D" ? !!d : mode === "P" ? !!p : !!(d && p);
-    if (!needed) return;
-
-    const key = cacheKey(mode, d, p);
-
-    // If this exact key already rendered and not forcing, skip
-    if (!force && lastMermaidKey.current === key && mermaidText) {
-      setMermaidStatus("verified");
-      return;
-    }
-
-    // Cache-first unless forced
-    if (!force) {
-      const cached = readMermaidCache(mode, d, p);
-      if (cached) {
-        setMermaidText(cached);
-        setMermaidStatus("verified");
-        lastMermaidKey.current = key;
-        return;
-      }
-    }
-
-    // Abort any in-flight call
-    mermaidAbort.current?.abort();
-    const ctrl = new AbortController();
-    mermaidAbort.current = ctrl;
-    const myId = ++mermaidReqSeq.current;
-
-    setMermaidStatus("ai-thinking");
-
-    try {
-      const res = await generateMermaid(toApiMode(mode), d, p, "", ctrl.signal);
-      if (myId !== mermaidReqSeq.current) return; // stale
-      if (res.result_status === "success" && res.mermaid) {
-        let out = res.mermaid.trim();
-        out = maybeFixMermaid(mode, out);
-        setMermaidText(out);
-        setMermaidStatus("verified");
-        writeMermaidCache(mode, d, p, out);
-        lastMermaidKey.current = key;
-      } else {
-        setMermaidStatus("error");
-        setMermaidText(
-          `%% Mermaid conversion failed${res.message ? `: ${res.message}` : ""}\nflowchart TD\n  A[Start] --> B[Check endpoint/mode/key];`
-        );
-      }
-    } catch (e: any) {
-      if (e?.name === "AbortError") return;
-      if (myId !== mermaidReqSeq.current) return;
-      setMermaidStatus("error");
-      setMermaidText(`%% Network error\nflowchart TD\n  A[Start] --> B[Retry request];`);
-    }
-  };
 
   /* --------------------------------- UI ----------------------------------- */
 
@@ -340,36 +135,15 @@ export default function PddlEditPage() {
       <div className="actions-dock">
         <div className="control-lane">
           {/* View toggle button */}
-          {showMermaid ? (
+          {isMermaidOpen ? (
             <PillButton
-              onClick={() => {
-                setShowMermaid(false);
-                setMermaidStatus("idle");
-              }}
+              onClick={closeMermaid}
               label="PDDL View"
               ariaLabel="Close Mermaid and return to PDDL editors"
             />
           ) : (
             <PillButton
-              onClick={() => {
-                if (!canConvertMermaid) return;
-                setShowMermaid(true);
-                const d = domain.trim();
-                const p = problem.trim();
-                const needed =
-                  mermaidUiMode === "D" ? !!d : mermaidUiMode === "P" ? !!p : !!(d && p);
-                if (!needed) return;
-
-                const cached = readMermaidCache(mermaidUiMode, d, p);
-                if (cached) {
-                  setMermaidText(cached);
-                  setMermaidStatus("verified");
-                  lastMermaidKey.current = cacheKey(mermaidUiMode, d, p);
-                } else {
-                  setMermaidStatus("ai-thinking");
-                  fetchMermaidFor(mermaidUiMode, true);
-                }
-              }}
+              onClick={openMermaid}
               label="Mermaid View"
               ariaLabel="Open Mermaid diagram"
               disabled={!canConvertMermaid}
@@ -449,29 +223,27 @@ export default function PddlEditPage() {
       {/* Content */}
       <div style={{ display: "grid", gap: "1rem", width: "min(1160px, 92vw)" }}>
         {/* Mermaid panel */}
-        {showMermaid && (
+        {isMermaidOpen && (
           <MermaidPanel
             mermaidText={mermaidText}
-            visible={showMermaid}
+            visible={isMermaidOpen}
             height="50vh"
             status={mermaidStatus}
-              statusHint={
-              mermaidStatus === "error" ? "Mermaid conversion failed." :
-              mermaidStatus === "verified" ? "Diagram is up to date." :
-              mermaidStatus === "ai-thinking" ? "Converting…" : undefined
+            statusHint={
+              mermaidStatus === "error"
+                ? "Mermaid conversion failed."
+                : mermaidStatus === "verified"
+                ? "Diagram is up to date."
+                : mermaidStatus === "ai-thinking"
+                ? "Converting…"
+                : undefined
             }
-            busy={mermaidStatus === "ai-thinking" || mermaidStatus === "verification"} // translucent overlay + glow
+            busy={mermaidStatus === "ai-thinking" || mermaidStatus === "verification"}
             editable
-            onTextChange={(next) => {
-              setMermaidText(next);
-              persistRawMermaid(mermaidUiMode, domain, problem, next); // persist raw edits
-              // mark this render as the current for the same inputs
-              lastMermaidKey.current = cacheKey(mermaidUiMode, domain.trim(), problem.trim());
-              setMermaidStatus("verified");
-            }}
-            onRetry={() => fetchMermaidFor(mermaidUiMode, /* force */ true)}
+            onTextChange={onMermaidTextChange}
+            onRetry={() => fetchMermaid(true)}
             rightHeader={
-              <ModeSlider<"D+P" | "D" | "P">
+              <ModeSlider<MermaidUiMode>
                 value={mermaidUiMode}
                 onChange={(k) => setMermaidUiMode(k)}
                 modes={[
@@ -512,7 +284,7 @@ export default function PddlEditPage() {
               },
               onSubmit: () => (domainMode === "AI" ? generateDomainNow(domain) : validateDomainNow(domain)),
               placeholder: domainMode === "AI" ? "Describe the domain in natural language…" : "(define (domain ...))",
-              height: showMermaid ? "16vh" : "55vh",
+              height: isMermaidOpen ? "16vh" : "55vh",
               autoResize: false,
               showStatusPill: true,
               status: domainStatus,
@@ -561,7 +333,7 @@ export default function PddlEditPage() {
                 problemMode === "AI"
                   ? "Describe the goal in natural language…"
                   : "(define (problem ...) (:domain ...))",
-              height: showMermaid ? "16vh" : "55vh",
+              height: isMermaidOpen ? "16vh" : "55vh",
               autoResize: false,
               showStatusPill: true,
               status: problemStatus,


### PR DESCRIPTION
## Summary
- add a `useMermaidPreview` hook that encapsulates mermaid caching, fetching, and preview state
- update the PDDL editor page to consume the hook API for toggling, retrying, and editing the diagram