### PR TITLE
Refactor mermaid preview request flow and add unit tests

### DIFF
--- a/Pianista-frontend/.gitignore
+++ b/Pianista-frontend/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.test-dist

--- a/Pianista-frontend/package.json
+++ b/Pianista-frontend/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node ./scripts/run-tests.mjs"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",

--- a/Pianista-frontend/scripts/run-tests.mjs
+++ b/Pianista-frontend/scripts/run-tests.mjs
@@ -1,0 +1,77 @@
+import { build } from "esbuild";
+import { mkdir, readdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, "..");
+const srcDir = path.join(projectRoot, "src");
+const outDir = path.join(projectRoot, ".test-dist");
+
+async function findTests(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await findTests(full)));
+    } else if (entry.isFile() && entry.name.endsWith(".test.ts")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+async function buildTests(tests) {
+  if (tests.length === 0) return;
+
+  const aliasPlugin = {
+    name: "alias",
+    setup(buildContext) {
+      buildContext.onResolve({ filter: /^@\// }, (args) => {
+        const rel = args.path.slice(2);
+        if (rel === "api/pianista/generateMermaid") {
+          return { path: path.join(srcDir, "hooks/mermaidPreview/__testStubs__/generateMermaid.ts") };
+        }
+        if (rel === "components/Inputbox/TextArea") {
+          return { path: path.join(srcDir, "hooks/mermaidPreview/__testStubs__/TextArea.ts") };
+        }
+        return { path: path.join(srcDir, rel) };
+      });
+    },
+  };
+
+  await build({
+    entryPoints: tests,
+    outdir: outDir,
+    outbase: srcDir,
+    format: "cjs",
+    bundle: true,
+    platform: "node",
+    target: ["node20"],
+    sourcemap: "inline",
+    plugins: [aliasPlugin],
+    external: ["node:test"],
+    logLevel: "silent",
+    outExtension: { ".js": ".cjs" },
+  });
+}
+
+async function run() {
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(outDir, { recursive: true });
+  const tests = await findTests(srcDir);
+  await buildTests(tests);
+  const child = spawn(process.execPath, ["--test", outDir], {
+    stdio: "inherit",
+  });
+  child.on("exit", (code) => {
+    process.exit(code ?? 1);
+  });
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/Pianista-frontend/src/hooks/mermaidPreview/__testStubs__/TextArea.ts
+++ b/Pianista-frontend/src/hooks/mermaidPreview/__testStubs__/TextArea.ts
@@ -1,0 +1,1 @@
+export type TextAreaStatus = "idle" | "verification" | "verified" | "error" | "ai-thinking";

--- a/Pianista-frontend/src/hooks/mermaidPreview/__testStubs__/generateMermaid.ts
+++ b/Pianista-frontend/src/hooks/mermaidPreview/__testStubs__/generateMermaid.ts
@@ -1,0 +1,17 @@
+export type MermaidMode = "none" | "domain" | "problem" | "plan";
+
+export type GenerateMermaidResult = {
+  result_status: "success" | "failure";
+  mermaid?: string;
+  message?: string;
+};
+
+export async function generateMermaid(
+  _mode: MermaidMode,
+  _domain: string,
+  _problem: string,
+  _plan?: string,
+  _signal?: AbortSignal
+): Promise<GenerateMermaidResult> {
+  return { result_status: "failure", message: "stub" };
+}

--- a/Pianista-frontend/src/hooks/mermaidPreview/cache.test.ts
+++ b/Pianista-frontend/src/hooks/mermaidPreview/cache.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { mermaidCache } from "./cache";
+import type { MermaidUiMode } from "./types";
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length() {
+    return this.store.size;
+  }
+
+  getItem(key: string) {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  setItem(key: string, value: string) {
+    this.store.set(key, String(value));
+  }
+
+  removeItem(key: string) {
+    this.store.delete(key);
+  }
+
+  clear() {
+    this.store.clear();
+  }
+
+  key(index: number) {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+}
+
+const keyFor = (mode: MermaidUiMode, d: string, p: string) => mermaidCache.key(mode, d.trim(), p.trim());
+
+beforeEach(() => {
+  globalThis.localStorage = new MemoryStorage();
+});
+
+describe("mermaidCache", () => {
+  it("returns empty string when the cache is cold", () => {
+    const result = mermaidCache.read("D+P", "domain", "problem");
+    assert.strictEqual(result, "");
+  });
+
+  it("persists and reads trimmed values", () => {
+    const key = keyFor("D", "domain", "problem");
+    mermaidCache.write("D", "  domain  ", "  problem  ", "graph");
+    assert.strictEqual(globalThis.localStorage.getItem(key), "graph");
+
+    const read = mermaidCache.read("D", "  domain  ", "  problem  ");
+    assert.strictEqual(read, "graph");
+  });
+
+  it("persistRaw stores without additional normalization", () => {
+    const key = keyFor("P", "d", "p");
+    mermaidCache.persistRaw("P", "d", "p", "graph");
+    assert.strictEqual(globalThis.localStorage.getItem(key), "graph");
+  });
+});

--- a/Pianista-frontend/src/hooks/mermaidPreview/cache.ts
+++ b/Pianista-frontend/src/hooks/mermaidPreview/cache.ts
@@ -1,0 +1,50 @@
+import type { MermaidUiMode } from "./types";
+
+function djb2(s: string) {
+  let h = 5381;
+  for (let i = 0; i < s.length; i += 1) {
+    h = ((h << 5) + h) ^ s.charCodeAt(i);
+  }
+  return (h >>> 0).toString(36);
+}
+
+function inputFor(mode: MermaidUiMode, domain: string, problem: string) {
+  if (mode === "D") return domain;
+  if (mode === "P") return problem;
+  return `${domain}\n${problem}`;
+}
+
+function cacheKey(mode: MermaidUiMode, domain: string, problem: string) {
+  return `mermaid_cache:${mode}:${djb2(inputFor(mode, domain, problem))}`;
+}
+
+function safeRead(key: string) {
+  try {
+    return localStorage.getItem(key) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function safeWrite(key: string, value: string) {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Swallow cache failures — they're non-critical.
+  }
+}
+
+export const mermaidCache = {
+  key: cacheKey,
+  read(mode: MermaidUiMode, domain: string, problem: string) {
+    return safeRead(cacheKey(mode, domain.trim(), problem.trim()));
+  },
+  write(mode: MermaidUiMode, domain: string, problem: string, mermaid: string) {
+    safeWrite(cacheKey(mode, domain.trim(), problem.trim()), mermaid);
+  },
+  persistRaw(mode: MermaidUiMode, domain: string, problem: string, text: string) {
+    safeWrite(cacheKey(mode, domain.trim(), problem.trim()), text);
+  },
+};
+
+export type MermaidCache = typeof mermaidCache;

--- a/Pianista-frontend/src/hooks/mermaidPreview/textTransforms.test.ts
+++ b/Pianista-frontend/src/hooks/mermaidPreview/textTransforms.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { fixProblemEdges, maybeFixMermaid } from "./textTransforms";
+
+const base = `flowchart TD
+  a --> |label| goal
+`;
+
+describe("textTransforms", () => {
+  it("inserts a goal node when problem edges target goal placeholders", () => {
+    const input = `flowchart TD\n  foo --> |something|\n`;
+    const result = fixProblemEdges(input);
+    assert.match(result, /goal\(\(goal\)\)/);
+    assert.match(result, /foo --> goal/);
+  });
+
+  it("does not duplicate goal nodes if one already exists", () => {
+    const input = `flowchart TD\n  goal((goal))\n  foo --> |gap| goal\n`;
+    const result = fixProblemEdges(input);
+    const matches = result.match(/goal\(\(goal\)\)/g) ?? [];
+    assert.strictEqual(matches.length, 1);
+  });
+
+  it("only fixes problem mermaid when the mode is problem", () => {
+    const problemResult = maybeFixMermaid("P", `flowchart TD\n  foo --> |gap|\n`);
+    const domainResult = maybeFixMermaid("D", base);
+    assert.match(problemResult, /goal/);
+    assert.strictEqual(domainResult, base);
+  });
+});

--- a/Pianista-frontend/src/hooks/mermaidPreview/textTransforms.ts
+++ b/Pianista-frontend/src/hooks/mermaidPreview/textTransforms.ts
@@ -1,0 +1,42 @@
+import type { MermaidUiMode } from "./types";
+
+function ensureGoalNode(text: string) {
+  if (/\bgoal\(\(/i.test(text)) return text;
+  const lines = text.split(/\r?\n/);
+  const problemIdx = lines.findIndex((line) => /subgraph\s+problem\b/i.test(line));
+  const graphIdx = lines.findIndex((line) => /^\s*graph\b/i.test(line));
+  const goalDef = "  goal((goal))";
+  if (problemIdx >= 0) lines.splice(problemIdx + 1, 0, goalDef);
+  else if (graphIdx >= 0) lines.splice(graphIdx + 1, 0, goalDef);
+  else lines.unshift(goalDef);
+  return lines.join("\n");
+}
+
+export function fixProblemEdges(src: string) {
+  let out = src;
+
+  out = out.replace(
+    /^(\s*[A-Za-z][\w-]*)\s*([-=]{2,}(?:>|)?)\s*\|[^|]*\|\s*$/gm,
+    (_m, lhs: string, edge: string) => `${lhs} ${edge} goal`
+  );
+
+  out = out.replace(
+    /(\s*[A-Za-z][\w-]*)\s*([-=]{2,}(?:>|)?)\s*\|[^|]*\|\s*(?=\s+[A-Za-z][\w-]*\s*(?:[-=]{2,}(?:>|)?|-->|==>))/g,
+    (_m, lhs: string, edge: string) => `${lhs} ${edge} goal `
+  );
+
+  out = out.replace(
+    /^(\s*[A-Za-z][\w-]*)\s*([-=]{2,}(?:>|)?)\s*\|\s*$/gm,
+    (_m, lhs: string, edge: string) => `${lhs} ${edge} goal`
+  );
+
+  if (/[\s-](goal)(?!\s*\(\()/i.test(out)) {
+    out = ensureGoalNode(out);
+  }
+
+  return out;
+}
+
+export function maybeFixMermaid(mode: MermaidUiMode, text: string) {
+  return mode === "P" ? fixProblemEdges(text) : text;
+}

--- a/Pianista-frontend/src/hooks/mermaidPreview/types.ts
+++ b/Pianista-frontend/src/hooks/mermaidPreview/types.ts
@@ -1,0 +1,9 @@
+export type MermaidUiMode = "D+P" | "D" | "P";
+
+export function needsDomain(mode: MermaidUiMode) {
+  return mode !== "P";
+}
+
+export function needsProblem(mode: MermaidUiMode) {
+  return mode !== "D";
+}

--- a/Pianista-frontend/src/hooks/mermaidPreview/useMermaidRequest.test.ts
+++ b/Pianista-frontend/src/hooks/mermaidPreview/useMermaidRequest.test.ts
@@ -1,0 +1,137 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import type { GenerateMermaidResult } from "@/api/pianista/generateMermaid";
+import { createMermaidRequestController } from "./useMermaidRequest";
+import type { MermaidCache } from "./cache";
+import type { MermaidUiMode } from "./types";
+
+type FetchArgs = {
+  mode: string;
+  domain: string;
+  problem: string;
+  signal?: AbortSignal;
+};
+
+const makeCache = () => {
+  const store = new Map<string, string>();
+  const key = (mode: MermaidUiMode, d: string, p: string) => `key:${mode}:${d.trim()}:${p.trim()}`;
+  const cache: MermaidCache = {
+    key,
+    read(mode, d, p) {
+      return store.get(key(mode, d, p)) ?? "";
+    },
+    write(mode, d, p, text) {
+      store.set(key(mode, d, p), text);
+    },
+    persistRaw(mode, d, p, text) {
+      store.set(key(mode, d, p), text);
+    },
+  };
+  return { cache, store, key };
+};
+
+const success = (graph: string): GenerateMermaidResult => ({ result_status: "success", mermaid: graph });
+
+describe("createMermaidRequestController", () => {
+  it("uses cached mermaid text when available", async () => {
+    const { cache, store, key } = makeCache();
+    store.set(key("D+P", "domain", "problem"), "cached graph");
+
+    const fetchCalls: FetchArgs[] = [];
+    const controller = createMermaidRequestController("domain", "problem", {
+      cache,
+      fetchMermaid: async (mode, domain, problem, _plan, signal) => {
+        fetchCalls.push({ mode, domain, problem, signal });
+        return success("fresh graph");
+      },
+    });
+
+    await controller.fetch("D+P");
+
+    const state = controller.getState();
+    assert.strictEqual(state.status, "verified");
+    assert.strictEqual(state.text, "cached graph");
+    assert.strictEqual(fetchCalls.length, 0);
+  });
+
+  it("fetches when cache is empty and updates status", async () => {
+    const { cache, store, key } = makeCache();
+    const statuses: string[] = [];
+    const controller = createMermaidRequestController("domain", "problem", {
+      cache,
+      fetchMermaid: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        return success("flowchart TD\n  A --> B\n");
+      },
+    });
+
+    controller.subscribe((state) => {
+      statuses.push(state.status);
+    });
+
+    await controller.fetch("D+P");
+
+    assert.deepEqual(statuses, ["idle", "ai-thinking", "verified"]);
+    const state = controller.getState();
+    assert.strictEqual(state.text, "flowchart TD\n  A --> B");
+    assert.strictEqual(store.get(key("D+P", "domain", "problem")), "flowchart TD\n  A --> B");
+  });
+
+  it("sets error state when the service fails", async () => {
+    const { cache } = makeCache();
+    const controller = createMermaidRequestController("domain", "problem", {
+      cache,
+      fetchMermaid: async () => ({ result_status: "failure", message: "nope" }),
+    });
+
+    await controller.fetch("D");
+
+    const state = controller.getState();
+    assert.strictEqual(state.status, "error");
+    assert.match(state.text, /Mermaid conversion failed: nope/);
+  });
+
+  it("persists manual edits and bypasses redundant fetches", async () => {
+    const { cache, store, key } = makeCache();
+    const controller = createMermaidRequestController("domain", "problem", {
+      cache,
+      fetchMermaid: async () => success("fresh"),
+    });
+
+    controller.setManualText("D+P", "  domain  ", "  problem  ", "manual");
+    assert.strictEqual(controller.getState().text, "manual");
+    assert.strictEqual(store.get(key("D+P", "domain", "problem")), "manual");
+
+    await controller.fetch("D+P");
+    assert.strictEqual(controller.getState().text, "manual");
+  });
+
+  it("cancels in-flight requests and returns to idle", async () => {
+    const { cache } = makeCache();
+    let aborted = false;
+    const controller = createMermaidRequestController("domain", "problem", {
+      cache,
+      fetchMermaid: async (_mode, _d, _p, _plan, signal) => {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(() => resolve(), 10);
+          signal?.addEventListener("abort", () => {
+            aborted = true;
+            clearTimeout(timer);
+            const err = new Error("aborted");
+            (err as { name: string }).name = "AbortError";
+            reject(err);
+          });
+        });
+        return success("graph");
+      },
+    });
+
+    const fetchPromise = controller.fetch("D");
+    controller.cancel();
+    await fetchPromise;
+
+    assert.strictEqual(aborted, true);
+    assert.strictEqual(controller.getState().status, "idle");
+  });
+});

--- a/Pianista-frontend/src/hooks/mermaidPreview/useMermaidRequest.ts
+++ b/Pianista-frontend/src/hooks/mermaidPreview/useMermaidRequest.ts
@@ -1,0 +1,188 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { generateMermaid, type MermaidMode } from "@/api/pianista/generateMermaid";
+import type { TextAreaStatus } from "@/components/Inputbox/TextArea";
+
+import { mermaidCache, type MermaidCache } from "./cache";
+import { maybeFixMermaid } from "./textTransforms";
+import type { MermaidUiMode } from "./types";
+
+function toApiMode(mode: MermaidUiMode): MermaidMode {
+  return mode === "D" ? "domain" : mode === "P" ? "problem" : "none";
+}
+
+function isAbortError(error: unknown): error is { name?: string } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name?: string }).name === "AbortError"
+  );
+}
+
+export type MermaidRequestState = {
+  status: TextAreaStatus;
+  text: string;
+};
+
+export type MermaidRequestController = {
+  getState: () => MermaidRequestState;
+  subscribe: (listener: (state: MermaidRequestState) => void) => () => void;
+  setInputs: (domain: string, problem: string) => void;
+  fetch: (mode: MermaidUiMode, options?: { force?: boolean }) => Promise<void>;
+  cancel: () => void;
+  setManualText: (mode: MermaidUiMode, domain: string, problem: string, next: string) => void;
+};
+
+type ControllerDeps = {
+  cache?: MermaidCache;
+  fetchMermaid?: typeof generateMermaid;
+};
+
+export function createMermaidRequestController(
+  initialDomain: string,
+  initialProblem: string,
+  deps: ControllerDeps = {}
+): MermaidRequestController {
+  const cache = deps.cache ?? mermaidCache;
+  const fetchMermaid = deps.fetchMermaid ?? generateMermaid;
+
+  let domain = initialDomain.trim();
+  let problem = initialProblem.trim();
+  let abortCtrl: AbortController | null = null;
+  let seq = 0;
+  let lastKey = "";
+  let latestText = "";
+
+  const listeners = new Set<(state: MermaidRequestState) => void>();
+  let state: MermaidRequestState = { status: "idle", text: "" };
+
+  const notify = () => {
+    for (const listener of listeners) listener(state);
+  };
+
+  const setState = (next: MermaidRequestState) => {
+    state = next;
+    latestText = next.text;
+    notify();
+  };
+
+  const ensureAbortClear = (ctrl: AbortController) => {
+    if (abortCtrl === ctrl) {
+      abortCtrl = null;
+    }
+  };
+
+  const controller: MermaidRequestController = {
+    getState: () => state,
+    subscribe(listener) {
+      listeners.add(listener);
+      listener(state);
+      return () => listeners.delete(listener);
+    },
+    setInputs(nextDomain, nextProblem) {
+      domain = nextDomain.trim();
+      problem = nextProblem.trim();
+      lastKey = "";
+    },
+    async fetch(mode, options = {}) {
+      const { force = false } = options;
+      const d = domain;
+      const p = problem;
+      const needed = mode === "D" ? !!d : mode === "P" ? !!p : !!(d && p);
+      if (!needed) return;
+
+      const key = cache.key(mode, d, p);
+
+      if (!force && lastKey === key && latestText) {
+        setState({ status: "verified", text: latestText });
+        return;
+      }
+
+      if (!force) {
+        const cached = cache.read(mode, d, p);
+        if (cached) {
+          setState({ status: "verified", text: cached });
+          lastKey = key;
+          return;
+        }
+      }
+
+      abortCtrl?.abort();
+      const ctrl = new AbortController();
+      abortCtrl = ctrl;
+      const requestId = ++seq;
+
+      setState({ status: "ai-thinking", text: state.text });
+
+      try {
+        const res = await fetchMermaid(toApiMode(mode), d, p, "", ctrl.signal);
+        if (requestId !== seq) return;
+        if (res.result_status === "success" && res.mermaid) {
+          const cleaned = maybeFixMermaid(mode, res.mermaid.trim());
+          cache.write(mode, d, p, cleaned);
+          lastKey = key;
+          setState({ status: "verified", text: cleaned });
+        } else {
+          setState({
+            status: "error",
+            text: `%% Mermaid conversion failed${res.message ? `: ${res.message}` : ""}\nflowchart TD\n  A[Start] --> B[Check endpoint/mode/key];`,
+          });
+        }
+      } catch (error) {
+        if (isAbortError(error)) return;
+        if (requestId !== seq) return;
+        setState({ status: "error", text: `%% Network error\nflowchart TD\n  A[Start] --> B[Retry request];` });
+      } finally {
+        ensureAbortClear(ctrl);
+      }
+    },
+    cancel() {
+      abortCtrl?.abort();
+      abortCtrl = null;
+      setState({ status: "idle", text: state.text });
+    },
+    setManualText(mode, rawDomain, rawProblem, next) {
+      const d = rawDomain.trim();
+      const p = rawProblem.trim();
+      cache.persistRaw(mode, d, p, next);
+      lastKey = cache.key(mode, d, p);
+      setState({ status: "verified", text: next });
+    },
+  };
+
+  return controller;
+}
+
+type UseMermaidRequestArgs = {
+  domain: string;
+  problem: string;
+};
+
+type UseMermaidRequestResult = {
+  status: TextAreaStatus;
+  text: string;
+  fetch: MermaidRequestController["fetch"];
+  cancel: MermaidRequestController["cancel"];
+  setManualText: MermaidRequestController["setManualText"];
+};
+
+export function useMermaidRequest({ domain, problem }: UseMermaidRequestArgs): UseMermaidRequestResult {
+  const controller = useMemo(() => createMermaidRequestController(domain, problem), []);
+
+  useEffect(() => {
+    controller.setInputs(domain, problem);
+  }, [controller, domain, problem]);
+
+  const [state, setState] = useState(controller.getState());
+
+  useEffect(() => controller.subscribe(setState), [controller]);
+
+  return {
+    status: state.status,
+    text: state.text,
+    fetch: controller.fetch,
+    cancel: controller.cancel,
+    setManualText: controller.setManualText,
+  };
+}

--- a/Pianista-frontend/src/hooks/useMermaidPreview.ts
+++ b/Pianista-frontend/src/hooks/useMermaidPreview.ts
@@ -1,91 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { generateMermaid, type MermaidMode } from "@/api/pianista/generateMermaid";
-import type { TextAreaStatus } from "@/components/Inputbox/TextArea";
+import { useMermaidRequest } from "./mermaidPreview/useMermaidRequest";
+import type { MermaidUiMode } from "./mermaidPreview/types";
 
-export type MermaidUiMode = "D+P" | "D" | "P";
-
-function djb2(s: string) {
-  let h = 5381;
-  for (let i = 0; i < s.length; i++) h = ((h << 5) + h) ^ s.charCodeAt(i);
-  return (h >>> 0).toString(36);
-}
-
-function inputFor(mode: MermaidUiMode, d: string, p: string) {
-  return mode === "D" ? d : mode === "P" ? p : `${d}\n${p}`;
-}
-
-function cacheKey(mode: MermaidUiMode, d: string, p: string) {
-  return `mermaid_cache:${mode}:${djb2(inputFor(mode, d, p))}`;
-}
-
-function readMermaidCache(mode: MermaidUiMode, d: string, p: string) {
-  try {
-    return localStorage.getItem(cacheKey(mode, d, p)) || "";
-  } catch {
-    return "";
-  }
-}
-
-function writeMermaidCache(mode: MermaidUiMode, d: string, p: string, mermaid: string) {
-  try {
-    localStorage.setItem(cacheKey(mode, d, p), mermaid);
-  } catch {
-    // noop — cache failures aren't critical
-  }
-}
-
-function persistRawMermaid(mode: MermaidUiMode, d: string, p: string, text: string) {
-  writeMermaidCache(mode, d.trim(), p.trim(), text);
-}
-
-function fixProblemEdges(src: string) {
-  let out = src;
-
-  const ensureGoalNode = (text: string) => {
-    if (/\bgoal\(\(/i.test(text)) return text;
-    const lines = text.split(/\r?\n/);
-    const problemIdx = lines.findIndex((l) => /subgraph\s+problem\b/i.test(l));
-    const graphIdx = lines.findIndex((l) => /^\s*graph\b/i.test(l));
-    const def = "  goal((goal))";
-    if (problemIdx >= 0) lines.splice(problemIdx + 1, 0, def);
-    else if (graphIdx >= 0) lines.splice(graphIdx + 1, 0, def);
-    else lines.unshift(def);
-    return lines.join("\n");
-  };
-
-  out = out.replace(
-    /^(\s*[A-Za-z][\w-]*)\s*([-=]{2,}(?:>|)?)\s*\|[^|]*\|\s*$/gm,
-    (_m, lhs, edge) => `${lhs} ${edge} goal`
-  );
-
-  out = out.replace(
-    /(\s*[A-Za-z][\w-]*)\s*([-=]{2,}(?:>|)?)\s*\|[^|]*\|\s*(?=\s+[A-Za-z][\w-]*\s*(?:[-=]{2,}(?:>|)?|-->|==>))/g,
-    (_m, lhs, edge) => `${lhs} ${edge} goal `
-  );
-
-  out = out.replace(
-    /^(\s*[A-Za-z][\w-]*)\s*([-=]{2,}(?:>|)?)\s*\|\s*$/gm,
-    (_m, lhs, edge) => `${lhs} ${edge} goal`
-  );
-
-  if (/[\s-](goal)(?!\s*\(\()/i.test(out)) {
-    out = ensureGoalNode(out);
-  }
-  return out;
-}
-
-function maybeFixMermaid(mode: MermaidUiMode, text: string) {
-  return mode === "P" ? fixProblemEdges(text) : text;
-}
-
-function isAbortError(error: unknown): error is { name?: string } {
-  return typeof error === "object" && error !== null && "name" in error && (error as { name?: string }).name === "AbortError";
-}
-
-function toApiMode(m: MermaidUiMode): MermaidMode {
-  return m === "D" ? "domain" : m === "P" ? "problem" : "none";
-}
+export type { MermaidUiMode } from "./mermaidPreview/types";
 
 export function useMermaidPreview({
   domain,
@@ -95,32 +13,13 @@ export function useMermaidPreview({
   problem: string;
 }) {
   const [isMermaidOpen, setIsMermaidOpen] = useState(false);
-  const [mermaidText, setMermaidText] = useState("");
-  const [mermaidStatus, setMermaidStatus] = useState<TextAreaStatus>("idle");
   const [mermaidUiMode, setMermaidUiMode] = useState<MermaidUiMode>("D+P");
-
-  const mermaidAbort = useRef<AbortController | null>(null);
-  const mermaidReqSeq = useRef(0);
-  const lastMermaidKey = useRef<string>("");
-  const mermaidAutoDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const latestMermaidText = useRef("");
-
-  useEffect(() => {
-    latestMermaidText.current = mermaidText;
-  }, [mermaidText]);
-
-  const cleanup = useCallback(() => {
-    mermaidAbort.current?.abort();
-    if (mermaidAutoDebounce.current) {
-      clearTimeout(mermaidAutoDebounce.current);
-      mermaidAutoDebounce.current = null;
-    }
-  }, []);
-
-  useEffect(() => cleanup, [cleanup]);
 
   const trimmedDomain = useMemo(() => domain.trim(), [domain]);
   const trimmedProblem = useMemo(() => problem.trim(), [problem]);
+
+  const { status: mermaidStatus, text: mermaidText, fetch: requestMermaid, cancel, setManualText } =
+    useMermaidRequest({ domain, problem });
 
   const canConvertMermaid = useMemo(() => {
     const dOk = !!trimmedDomain;
@@ -130,143 +29,42 @@ export function useMermaidPreview({
     return dOk && pOk;
   }, [trimmedDomain, trimmedProblem, mermaidUiMode]);
 
-  const fetchMermaidInternal = useCallback(
-    async (mode: MermaidUiMode, force = false) => {
-      const d = trimmedDomain;
-      const p = trimmedProblem;
-      const needed = mode === "D" ? !!d : mode === "P" ? !!p : !!(d && p);
-      if (!needed) return;
-
-      const key = cacheKey(mode, d, p);
-
-      if (!force && lastMermaidKey.current === key && latestMermaidText.current) {
-        setMermaidStatus("verified");
-        return;
-      }
-
-      if (!force) {
-        const cached = readMermaidCache(mode, d, p);
-        if (cached) {
-          setMermaidText(cached);
-          setMermaidStatus("verified");
-          lastMermaidKey.current = key;
-          return;
-        }
-      }
-
-      mermaidAbort.current?.abort();
-      const ctrl = new AbortController();
-      mermaidAbort.current = ctrl;
-      const myId = ++mermaidReqSeq.current;
-
-      setMermaidStatus("ai-thinking");
-
-      try {
-        const res = await generateMermaid(toApiMode(mode), d, p, "", ctrl.signal);
-        if (myId !== mermaidReqSeq.current) return;
-        if (res.result_status === "success" && res.mermaid) {
-          let out = res.mermaid.trim();
-          out = maybeFixMermaid(mode, out);
-          setMermaidText(out);
-          setMermaidStatus("verified");
-          writeMermaidCache(mode, d, p, out);
-          lastMermaidKey.current = key;
-        } else {
-          setMermaidStatus("error");
-          setMermaidText(
-            `%% Mermaid conversion failed${res.message ? `: ${res.message}` : ""}\nflowchart TD\n  A[Start] --> B[Check endpoint/mode/key];`
-          );
-        }
-      } catch (error) {
-        if (isAbortError(error)) return;
-        if (myId !== mermaidReqSeq.current) return;
-        setMermaidStatus("error");
-        setMermaidText(`%% Network error\nflowchart TD\n  A[Start] --> B[Retry request];`);
-      }
-    },
-    [trimmedDomain, trimmedProblem]
-  );
-
   const fetchMermaid = useCallback(
-    (force = false) => fetchMermaidInternal(mermaidUiMode, force),
-    [fetchMermaidInternal, mermaidUiMode]
+    (force = false) => requestMermaid(mermaidUiMode, { force }),
+    [requestMermaid, mermaidUiMode]
   );
 
   useEffect(() => {
     if (!isMermaidOpen) return;
     if (!canConvertMermaid) return;
 
-    if (mermaidAutoDebounce.current) clearTimeout(mermaidAutoDebounce.current);
-    setMermaidStatus("ai-thinking");
-    mermaidAutoDebounce.current = setTimeout(() => {
-      fetchMermaidInternal(mermaidUiMode, true);
+    const handle = window.setTimeout(() => {
+      requestMermaid(mermaidUiMode, { force: true });
     }, 300);
 
-    return () => {
-      if (mermaidAutoDebounce.current) {
-        clearTimeout(mermaidAutoDebounce.current);
-        mermaidAutoDebounce.current = null;
-      }
-    };
-  }, [trimmedDomain, trimmedProblem, isMermaidOpen, canConvertMermaid, fetchMermaidInternal, mermaidUiMode]);
+    return () => clearTimeout(handle);
+  }, [isMermaidOpen, canConvertMermaid, requestMermaid, mermaidUiMode, trimmedDomain, trimmedProblem]);
 
   useEffect(() => {
     if (!isMermaidOpen) return;
-    const d = trimmedDomain;
-    const p = trimmedProblem;
-    const needed = mermaidUiMode === "D" ? !!d : mermaidUiMode === "P" ? !!p : !!(d && p);
-    if (!needed) return;
-
-    const key = cacheKey(mermaidUiMode, d, p);
-
-    if (lastMermaidKey.current === key && latestMermaidText.current) {
-      setMermaidStatus("verified");
-      return;
-    }
-
-    const cached = readMermaidCache(mermaidUiMode, d, p);
-    if (cached) {
-      setMermaidText(cached);
-      setMermaidStatus("verified");
-      lastMermaidKey.current = key;
-      return;
-    }
-
-    setMermaidStatus("ai-thinking");
-    fetchMermaidInternal(mermaidUiMode, true);
-  }, [mermaidUiMode, isMermaidOpen, trimmedDomain, trimmedProblem, fetchMermaidInternal]);
+    requestMermaid(mermaidUiMode);
+  }, [isMermaidOpen, mermaidUiMode, requestMermaid]);
 
   const openMermaid = useCallback(() => {
     if (!canConvertMermaid) return;
     setIsMermaidOpen(true);
-    const d = trimmedDomain;
-    const p = trimmedProblem;
-    const key = cacheKey(mermaidUiMode, d, p);
-    const cached = readMermaidCache(mermaidUiMode, d, p);
-    if (cached) {
-      setMermaidText(cached);
-      setMermaidStatus("verified");
-      lastMermaidKey.current = key;
-    } else {
-      setMermaidStatus("ai-thinking");
-      fetchMermaidInternal(mermaidUiMode, true);
-    }
-  }, [canConvertMermaid, trimmedDomain, trimmedProblem, mermaidUiMode, fetchMermaidInternal]);
+  }, [canConvertMermaid]);
 
   const closeMermaid = useCallback(() => {
     setIsMermaidOpen(false);
-    setMermaidStatus("idle");
-    cleanup();
-  }, [cleanup]);
+    cancel();
+  }, [cancel]);
 
   const onMermaidTextChange = useCallback(
     (next: string) => {
-      setMermaidText(next);
-      persistRawMermaid(mermaidUiMode, domain, problem, next);
-      lastMermaidKey.current = cacheKey(mermaidUiMode, trimmedDomain, trimmedProblem);
-      setMermaidStatus("verified");
+      setManualText(mermaidUiMode, domain, problem, next);
     },
-    [domain, problem, mermaidUiMode, trimmedDomain, trimmedProblem]
+    [setManualText, mermaidUiMode, domain, problem]
   );
 
   return {


### PR DESCRIPTION
## Summary
- factor the mermaid preview cache and text transformation helpers into dedicated modules with targeted unit tests
- introduce a reusable mermaid request controller/hook and simplify the preview hook to focus on UI state
- add an esbuild-based Node test runner script with local stubs so the new tests run without external dependencies

## Testing
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d83ab397c0832f9ddbd17a014ab336