### PR TITLE
Refactor MiniZinc editors into reusable card component

### DIFF
--- a/Pianista-frontend/src/pages/minizinc.tsx
+++ b/Pianista-frontend/src/pages/minizinc.tsx
@@ -5,6 +5,7 @@ import Textarea, { type TextAreaStatus } from "@/components/Inputbox/TextArea";
 import PillButton from "@/components/PillButton";
 import { generateSolution } from "@/api/pianista/generateSolution";
 import getSolution from "@/api/pianista/getSolution";
+import MiniZincEditorCard from "./minizinc/MiniZincEditorCard";
 
 type Phase = "compose" | "result";
 type RunState = "idle" | "submitting" | "polling" | "error" | "done";
@@ -181,100 +182,25 @@ while (attempt < maxPolls && aliveRef.current) {
               alignItems: "stretch",
             }}
           >
-          {/* Left: Model (.mzn) */}
-          <section
-            style={{
-              display: "grid",
-              gridTemplateRows: "auto 1fr",
-              height: "48vh",
-              minHeight: 320,
-              border: "1px solid var(--color-border-muted)",
-              borderRadius: 12,
-              background: "var(--color-surface)",
-              boxShadow: "0 1px 4px var(--color-shadow) inset",
-              overflow: "hidden",
-            }}
-          >
-            {/* Header/title INSIDE the container */}
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                padding: "10px 12px",
-                borderBottom: "1px solid var(--color-border-muted)",
-                fontWeight: 600,
-              }}
-            >
-              <span>Model (.mzn)</span>
-              {/* (Optional) status pill could also live here if you want */}
-            </div>
+            <MiniZincEditorCard
+              title="Model (.mzn)"
+              value={modelStr}
+              onChange={setModelStr}
+              status={modelStatus}
+              statusHint={statusHint || undefined}
+              placeholder="Write your MiniZinc model here"
+              disabled={isBusy}
+            />
 
-            {/* Content area with small inner gap */}
-            <div style={{ padding: 8, display: "grid" }}>
-              <Textarea
-                value={modelStr}
-                onChange={setModelStr}
-                style={{ height: "100%" } as React.CSSProperties}  // fills the content area
-                autoResize={false}
-                minRows={12}
-                maxRows={24}
-                width="100%"
-                placeholder="Write your MiniZinc model here"
-                disabled={isBusy}
-                showStatusPill
-                status={modelStatus}
-                statusHint={statusHint || undefined}
-              />
-            </div>
-          </section>
-
-
-          {/* Right: Parameters (JSON) */}
-          <section
-            style={{
-              display: "grid",
-              gridTemplateRows: "auto 1fr",
-              height: "48vh",
-              minHeight: 320,
-              border: "1px solid var(--color-border-muted)",
-              borderRadius: 12,
-              background: "var(--color-surface)",
-              boxShadow: "0 1px 4px var(--color-shadow) inset",
-              overflow: "hidden",
-            }}
-          >
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                padding: "10px 12px",
-                borderBottom: "1px solid var(--color-border-muted)",
-                fontWeight: 600,
-              }}
-            >
-              <span>Parameters (JSON)</span>
-            </div>
-
-            <div style={{ padding: 8, display: "grid" }}>
-              <Textarea
-                value={paramsText}
-                onChange={setParamsText}
-                style={{ height: "100%" } as React.CSSProperties}
-                autoResize={false}
-                minRows={12}
-                maxRows={24}
-                width="100%"
-                placeholder='e.g. { "target": 199 }'
-                disabled={isBusy}
-                showStatusPill
-                status={paramsStatus}
-                statusHint={statusHint || undefined}
-              />
-            </div>
-          </section>
-
+            <MiniZincEditorCard
+              title="Parameters (JSON)"
+              value={paramsText}
+              onChange={setParamsText}
+              status={paramsStatus}
+              statusHint={statusHint || undefined}
+              placeholder='e.g. { "target": 199 }'
+              disabled={isBusy}
+            />
           </div>
 
           {/* Button row — below & right-aligned */}

--- a/Pianista-frontend/src/pages/minizinc/MiniZincEditorCard.tsx
+++ b/Pianista-frontend/src/pages/minizinc/MiniZincEditorCard.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import Textarea, { type TextAreaStatus } from "@/components/Inputbox/TextArea";
+
+type MiniZincEditorCardProps = {
+  title: string;
+  value: string;
+  onChange: (value: string) => void;
+  status: TextAreaStatus;
+  statusHint?: string;
+  placeholder?: string;
+  disabled?: boolean;
+};
+
+const cardStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateRows: "auto 1fr",
+  height: "48vh",
+  minHeight: 320,
+  border: "1px solid var(--color-border-muted)",
+  borderRadius: 12,
+  background: "var(--color-surface)",
+  boxShadow: "0 1px 4px var(--color-shadow) inset",
+  overflow: "hidden",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  padding: "10px 12px",
+  borderBottom: "1px solid var(--color-border-muted)",
+  fontWeight: 600,
+};
+
+const contentStyle: React.CSSProperties = {
+  padding: 8,
+  display: "grid",
+};
+
+export default function MiniZincEditorCard({
+  title,
+  value,
+  onChange,
+  status,
+  statusHint,
+  placeholder,
+  disabled,
+}: MiniZincEditorCardProps) {
+  return (
+    <section style={cardStyle}>
+      <div style={headerStyle}>
+        <span>{title}</span>
+      </div>
+      <div style={contentStyle}>
+        <Textarea
+          value={value}
+          onChange={onChange}
+          style={{ height: "100%" } as React.CSSProperties}
+          autoResize={false}
+          minRows={12}
+          maxRows={24}
+          width="100%"
+          placeholder={placeholder}
+          disabled={disabled}
+          showStatusPill
+          status={status}
+          statusHint={statusHint}
+        />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- extract the shared MiniZinc editor section markup into a reusable MiniZincEditorCard component
- replace the inline model and parameter sections on the MiniZinc page with the new component

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d8482c3188832f9c3d1a17b20c8cc2