### PR TITLE
Refactor gantt-lite helpers and layout

### DIFF
--- a/Pianista-frontend/src/components/gantt-lite/GanttHeader.tsx
+++ b/Pianista-frontend/src/components/gantt-lite/GanttHeader.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+
+const baseStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 12,
+  padding: "10px 12px",
+  flexShrink: 0,
+};
+
+const boxedStyle: React.CSSProperties = {
+  borderBottom: "1px solid var(--color-border-muted)",
+  background: "var(--color-surface-bridge)",
+};
+
+const unboxedStyle: React.CSSProperties = {
+  borderBottom: "none",
+  background: "transparent",
+};
+
+type Props = {
+  planner?: string;
+  boxed: boolean;
+  pxPerUnit: number;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onPxPerUnitChange: (value: number) => void;
+};
+
+export const GanttHeader: React.FC<Props> = ({
+  planner,
+  boxed,
+  pxPerUnit,
+  onZoomIn,
+  onZoomOut,
+  onPxPerUnitChange,
+}) => (
+  <div style={{ ...baseStyle, ...(boxed ? boxedStyle : unboxedStyle) }}>
+    <div style={{ fontSize: 14, fontWeight: 700 }}>
+      Timeline {planner ? `· ${planner}` : ""}
+    </div>
+    <div style={{ flex: 1 }} />
+    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+      <button onClick={onZoomOut} className="btn btn--surface btn--sm" aria-label="Zoom out">
+        –
+      </button>
+      <input
+        type="range"
+        min={8}
+        max={256}
+        step={1}
+        value={pxPerUnit}
+        onChange={(e) => onPxPerUnitChange(Number(e.target.value))}
+        style={{ width: 160, accentColor: "var(--color-accent)" }}
+        aria-label="Adjust zoom"
+      />
+      <button onClick={onZoomIn} className="btn btn--surface btn--sm" aria-label="Zoom in">
+        +
+      </button>
+    </div>
+  </div>
+);
+
+export default GanttHeader;

--- a/Pianista-frontend/src/components/gantt-lite/GanttLegend.tsx
+++ b/Pianista-frontend/src/components/gantt-lite/GanttLegend.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+type Props = {
+  boxed: boolean;
+  actionColors: Map<string, string>;
+  timeUnit: string;
+  maxDuration: number;
+};
+
+const baseStyle: React.CSSProperties = {
+  padding: "8px 12px",
+  display: "flex",
+  gap: 14,
+  flexWrap: "wrap",
+  alignItems: "center",
+  color: "var(--color-text)",
+  flexShrink: 0,
+};
+
+const boxedStyle: React.CSSProperties = {
+  borderTop: "1px solid var(--color-border-muted)",
+  background: "var(--color-surface-bridge)",
+};
+
+const unboxedStyle: React.CSSProperties = {
+  borderTop: "none",
+  background: "transparent",
+};
+
+export const GanttLegend: React.FC<Props> = ({ boxed, actionColors, timeUnit, maxDuration }) => (
+  <div style={{ ...baseStyle, ...(boxed ? boxedStyle : unboxedStyle) }}>
+    {Array.from(actionColors.entries()).map(([action, color]) => (
+      <div key={action} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12 }}>
+        <span aria-hidden style={{ width: 10, height: 10, borderRadius: 3, background: color }} />
+        <span style={{ opacity: 0.9, fontWeight: 700 }}>{action}</span>
+      </div>
+    ))}
+    <div style={{ marginLeft: "auto", fontSize: 12, opacity: 0.75 }}>
+      unit: <strong>{timeUnit}</strong> · duration: <strong>{Math.ceil(maxDuration)}</strong>
+    </div>
+  </div>
+);
+
+export default GanttLegend;

--- a/Pianista-frontend/src/components/gantt-lite/processing.ts
+++ b/Pianista-frontend/src/components/gantt-lite/processing.ts
@@ -1,0 +1,119 @@
+import { useMemo } from "react";
+
+export type TimeUnit = "second" | "minute" | "hour" | "day";
+
+export interface PlanTask {
+  action: string;
+  args: string[];
+  start?: number;
+  duration?: number;
+}
+
+export interface PlanMetrics {
+  "total-duration"?: number;
+  planner?: string;
+  status?: string;
+  "actions-used"?: number;
+}
+
+export interface PlanData {
+  plan: PlanTask[];
+  metrics?: PlanMetrics;
+}
+
+export interface ProcessedTask {
+  id: string;
+  action: string;
+  satellite: string;
+  target: string;
+  start: number;
+  duration: number;
+  end: number;
+  subRow: number;
+}
+
+export interface ProcessedLane {
+  name: string;
+  tasks: ProcessedTask[];
+  maxRows: number;
+}
+
+export interface ProcessedData {
+  lanes: ProcessedLane[];
+  maxDuration: number;
+}
+
+export const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+export const R = (n: number) => Math.round(n);
+export const ceil = Math.ceil;
+export const floor = Math.floor;
+
+const hash = (s: string) => {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < s.length; i++) h = Math.imul(h ^ s.charCodeAt(i), 16777619);
+  return h >>> 0;
+};
+
+export const colorFor = (key: string) => `hsl(${hash(key) % 360} 62% 52%)`;
+
+export const textOn = (hsl: string) =>
+  /hsl\(\s*\d+\s+\d+%\s+(\d+)%\s*\)/i.test(hsl) && Number(RegExp.$1) > 60
+    ? "var(--color-bg)"
+    : "#fff";
+
+export function toProcessed(planData: PlanData): ProcessedData {
+  const tasks: ProcessedTask[] = [];
+  let cursor = 0;
+
+  planData.plan.forEach((t, i) => {
+    const start = Number.isFinite(t.start as number) ? Math.max(0, Math.floor(t.start!)) : cursor;
+    const duration = Number.isFinite(t.duration as number) ? Math.max(1, Math.ceil(t.duration!)) : 1;
+    const satellite = t.args?.[0] ?? t.action;
+    const target = t.args?.[1] ?? "";
+    tasks.push({
+      id: `${satellite}:${t.action}:${i}`,
+      action: t.action,
+      satellite,
+      target,
+      start,
+      duration,
+      end: start + duration,
+      subRow: 0,
+    });
+    if (!Number.isFinite(t.start as number)) cursor += duration;
+  });
+
+  const laneMap = new Map<string, ProcessedLane>();
+  for (const tk of tasks) {
+    if (!laneMap.has(tk.satellite)) laneMap.set(tk.satellite, { name: tk.satellite, tasks: [], maxRows: 1 });
+    laneMap.get(tk.satellite)!.tasks.push(tk);
+  }
+
+  for (const lane of laneMap.values()) {
+    const rows: ProcessedTask[][] = [[]];
+    for (const tk of lane.tasks.sort((a, b) => a.start - b.start || a.end - b.end)) {
+      let placed = false;
+      for (let r = 0; r < rows.length; r++) {
+        const last = rows[r][rows[r].length - 1];
+        if (!last || last.end <= tk.start) {
+          tk.subRow = r;
+          rows[r].push(tk);
+          placed = true;
+          break;
+        }
+      }
+      if (!placed) {
+        tk.subRow = rows.length;
+        rows.push([tk]);
+      }
+    }
+    lane.maxRows = rows.length;
+  }
+
+  const maxDuration =
+    planData.metrics?.["total-duration"] ?? tasks.reduce((mx, t) => Math.max(mx, t.end), 0);
+
+  return { lanes: Array.from(laneMap.values()), maxDuration };
+}
+
+export const useProcessedPlan = (planData: PlanData) => useMemo(() => toProcessed(planData), [planData]);

--- a/Pianista-frontend/src/components/gantt-lite/useTooltip.ts
+++ b/Pianista-frontend/src/components/gantt-lite/useTooltip.ts
@@ -1,0 +1,56 @@
+import { useCallback, useState } from "react";
+import type { ProcessedTask, TimeUnit } from "./processing";
+
+type TooltipState = { x: number; y: number; html: string } | null;
+
+type UseTooltipOptions = {
+  enabled: boolean;
+  timeUnit: TimeUnit;
+};
+
+export const useTooltip = ({ enabled, timeUnit }: UseTooltipOptions) => {
+  const [hoverId, setHoverId] = useState<string | null>(null);
+  const [tip, setTip] = useState<TooltipState>(null);
+
+  const onEnter = useCallback(
+    (e: React.MouseEvent<HTMLElement>, tk: ProcessedTask) => {
+      setHoverId(tk.id);
+      if (!enabled) return;
+
+      const targetEl = e.currentTarget as HTMLElement;
+      const barRect = targetEl.getBoundingClientRect();
+
+      const offset = 12;
+      const baseX = barRect.right + offset;
+      const baseY = barRect.top + barRect.height / 2;
+
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const margin = 12;
+
+      const preferredX = baseX > vw - 180 ? barRect.left - offset : baseX;
+      const x = Math.max(margin, Math.min(preferredX, vw - margin));
+      const y = Math.max(margin, Math.min(baseY, vh - margin));
+
+      const duration = tk.end - tk.start;
+      const title = `${tk.action}${tk.target ? " → " + tk.target : ""}`;
+      const sub = `${tk.start}–${tk.end} ${timeUnit} • Δ${duration}`;
+
+      const html =
+        `<div style="font-weight:600">${title}</div>` +
+        `<div style="opacity:.8;font-size:11px;line-height:1.2">${sub}</div>`;
+
+      setTip({ x, y, html });
+    },
+    [enabled, timeUnit]
+  );
+
+  const onLeave = useCallback(() => {
+    setHoverId(null);
+    setTip(null);
+  }, []);
+
+  return { hoverId, tip, onEnter, onLeave };
+};
+
+export type UseTooltipResult = ReturnType<typeof useTooltip>;


### PR DESCRIPTION
## Summary
- extract plan processing helpers into src/components/gantt-lite/processing.ts and consume them from the Gantt component
- introduce a reusable useTooltip hook plus standalone header and legend components to simplify gantt-lite.tsx
- refactor gantt-lite.tsx to focus on layout, wiring the new helpers and maintaining existing visuals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d84dc02140832fab033051ea8e2b2a