### PR TITLE
feat: align floating actions with reusable action bar

### DIFF
--- a/Pianista-frontend/src/components/layout/ActionBar.tsx
+++ b/Pianista-frontend/src/components/layout/ActionBar.tsx
@@ -1,0 +1,28 @@
+import type { CSSProperties, PropsWithChildren } from "react";
+
+export type ActionBarProps = PropsWithChildren<{
+  className?: string;
+  style?: CSSProperties;
+  laneClassName?: string;
+  laneStyle?: CSSProperties;
+}>;
+
+function cx(...parts: Array<string | undefined | false | null>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+export default function ActionBar({
+  children,
+  className,
+  style,
+  laneClassName,
+  laneStyle,
+}: ActionBarProps) {
+  return (
+    <div className={cx("action-bar", className)} style={style}>
+      <div className={cx("action-bar__lane", laneClassName)} style={laneStyle}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/Pianista-frontend/src/pages/chat.tsx
+++ b/Pianista-frontend/src/pages/chat.tsx
@@ -15,6 +15,7 @@ import AddShortcutModal from "@/components/AddShortcutModal";
 import { useSlashMenu } from "@/hooks/useSlashMenu";
 import { useChatComposer } from "@/hooks/useChatComposer";
 import type { Mode } from "@/hooks/useChatComposer";
+import ActionBar from "@/components/layout/ActionBar";
 
 const ChatPage: React.FC = () => {
   const { name } = useTheme();
@@ -100,10 +101,9 @@ const ChatPage: React.FC = () => {
 
       <AddShortcutModal open={showCreate} onClose={() => setShowCreate(false)} onCreate={addShortcut} />
 
-      {/* Keeping existing FAB for now; layout modularization comes later */}
-      <div style={{ position: "fixed", left: "45%", right: 100, bottom: 10, zIndex: 40 }}>
+      <ActionBar>
         <PillButton to="/minizinc" ariaLabel="Go to MiniZinc Solver" label="Go to Solver" />
-      </div>
+      </ActionBar>
     </main>
   );
 };

--- a/Pianista-frontend/src/pages/minizinc.tsx
+++ b/Pianista-frontend/src/pages/minizinc.tsx
@@ -6,6 +6,7 @@ import PillButton from "@/components/PillButton";
 import { generateSolution } from "@/api/pianista/generateSolution";
 import getSolution from "@/api/pianista/getSolution";
 import MiniZincEditorCard from "./minizinc/MiniZincEditorCard";
+import ActionBar from "@/components/layout/ActionBar";
 
 type Phase = "compose" | "result";
 type RunState = "idle" | "submitting" | "polling" | "error" | "done";
@@ -258,21 +259,13 @@ while (attempt < maxPolls && aliveRef.current) {
           </div>
         )}
       </div>
-            <div
-              style={{
-                position: "fixed",
-                left: "45%", 
-                right: 100,
-                bottom: 10,
-                zIndex: 40,
-              }}
-            >
-              <PillButton
-                to="/chat"
-                ariaLabel="Go to Chat"
-                label="Go to Chat"
-              />
-            </div>
+      <ActionBar>
+        <PillButton
+          to="/chat"
+          ariaLabel="Go to Chat"
+          label="Go to Chat"
+        />
+      </ActionBar>
     </main>
   );
 }

--- a/Pianista-frontend/src/pages/pddl-edit.tsx
+++ b/Pianista-frontend/src/pages/pddl-edit.tsx
@@ -12,6 +12,7 @@ import Spinner from "@/components/icons/Spinner";
 import Brain from "@/components/icons/Brain";
 import Check from "@/components/icons/Check";
 import Reload from "@/components/icons/Reload";
+import ActionBar from "@/components/layout/ActionBar";
 
 import { useTwoModeAutoDetect, type TwoMode } from "@/hooks/useTwoModeAutoDetect";
 import {
@@ -131,77 +132,74 @@ export default function PddlEditPage() {
     >
       <BrandLogo />
 
-      {/* Floating actions dock (same level as footer; not fused) */}
-      <div className="actions-dock">
-        <div className="control-lane">
-          {/* View toggle button */}
-          {isMermaidOpen ? (
-            <PillButton
-              onClick={closeMermaid}
-              label="PDDL View"
-              ariaLabel="Close Mermaid and return to PDDL editors"
-            />
-          ) : (
-            <PillButton
-              onClick={openMermaid}
-              label="Mermaid View"
-              ariaLabel="Open Mermaid diagram"
-              disabled={!canConvertMermaid}
-            />
-          )}
-
-          <PlannerDropup
-            value={selectedPlanner}
-            onChange={setSelectedPlanner}
+      <ActionBar>
+        {/* View toggle button */}
+        {isMermaidOpen ? (
+          <PillButton
+            onClick={closeMermaid}
+            label="PDDL View"
+            ariaLabel="Close Mermaid and return to PDDL editors"
           />
+        ) : (
+          <PillButton
+            onClick={openMermaid}
+            label="Mermaid View"
+            ariaLabel="Open Mermaid diagram"
+            disabled={!canConvertMermaid}
+          />
+        )}
 
-          {/* Generate (uses your original glow-pulse while busy) */}
-          {planPhase === "success" ? (
+        <PlannerDropup
+          value={selectedPlanner}
+          onChange={setSelectedPlanner}
+        />
+
+        {/* Generate (uses your original glow-pulse while busy) */}
+        {planPhase === "success" ? (
+          <PillButton
+            to={`/plan?job=${encodeURIComponent(planId)}`}
+            label=" See Plan  "
+            rightIcon={<Check />}
+            ariaLabel="See generated plan"
+          />
+        ) : (
+          <div
+            className={planPhase === "submitting" || planPhase === "polling" ? "glow-pulse" : ""}
+            style={{ display: "inline-flex", borderRadius: 10 }}
+          >
             <PillButton
-              to={`/plan?job=${encodeURIComponent(planId)}`}
-              label=" See Plan  "
-              rightIcon={<Check />}
-              ariaLabel="See generated plan"
+              onClick={handleGeneratePlan}
+              label={
+                planPhase === "submitting" || planPhase === "polling"
+                  ? genLabel
+                  : "Generate Plan"
+              }
+              rightIcon={
+                planPhase === "submitting" ? <Spinner /> :
+                planPhase === "polling" ? <Brain /> :
+                undefined
+              }
+              disabled={!canGenerate || planPhase === "submitting" || planPhase === "polling"}
+              ariaLabel="Generate plan from current PDDL"
             />
-          ) : (
-            <div
-              className={planPhase === "submitting" || planPhase === "polling" ? "glow-pulse" : ""}
-              style={{ display: "inline-flex", borderRadius: 10 }}
-            >
-              <PillButton
-                onClick={handleGeneratePlan}
-                label={
-                  planPhase === "submitting" || planPhase === "polling"
-                    ? genLabel
-                    : "Generate Plan"
-                }
-                rightIcon={
-                  planPhase === "submitting" ? <Spinner /> :
-                  planPhase === "polling" ? <Brain /> :
-                  undefined
-                }
-                disabled={!canGenerate || planPhase === "submitting" || planPhase === "polling"}
-                ariaLabel="Generate plan from current PDDL"
-              />
-            </div>
-          )}
-          {/* Reset button — now to the RIGHT of Generate; reserved width prevents shifting */}
-          <div className="reset-slot">
-            {planPhase === "success" && (
-              <PillButton
-                onClick={handleRegenerate}
-                iconOnly
-                rightIcon={<Reload className="icon-accent"/>}
-                ariaLabel="Clear Plan"
-                style={{
-                    width: 30,
-                    height: 30,
-                }}
-              />
-            )}
           </div>
+        )}
+        {/* Reset button — now to the RIGHT of Generate; reserved width prevents shifting */}
+        <div className="reset-slot">
+          {planPhase === "success" && (
+            <PillButton
+              onClick={handleRegenerate}
+              iconOnly
+              rightIcon={<Reload className="icon-accent"/>}
+              ariaLabel="Clear Plan"
+              style={{
+                  width: 30,
+                  height: 30,
+              }}
+            />
+          )}
         </div>
-      </div>
+      </ActionBar>
 
 
 

--- a/Pianista-frontend/src/theme.css
+++ b/Pianista-frontend/src/theme.css
@@ -372,31 +372,27 @@ section[data-busy-glow="true"] {
   backdrop-filter: blur(6px);
   box-shadow: 0 2px 12px var(--color-shadow);
 }
-:root{
-  /* tweak this to nudge the dock horizontally relative to page center */
-  --actions-offset: 220px;
-}
-
-/* Floating actions dock at same level as footer (not fused) */
-.actions-dock {
+/* Floating actions bar shared across pages */
+.action-bar {
   position: fixed;
   left: 50%;
-  bottom: 3px;                 /* same bottom spacing as footer chip */
-  transform: translateX(var(--actions-offset));
-  z-index: 11;                 /* above content; below modals */
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  pointer-events: none;        /* so it doesn’t block page clicks... */
+  bottom: calc(56px + env(safe-area-inset-bottom));
+  transform: translateX(-50%);
+  z-index: 11; /* above content; below modals */
+  width: min(100vw, 960px);
+  padding: 0 16px;
+  pointer-events: none; /* so it doesn’t block page clicks... */
+  display: flex;
+  justify-content: center;
 }
-.actions-dock > * { pointer-events: auto; } /* ...but its children do */
 
-/* optional: visually align height with footer chip without adding a box */
-.actions-dock .control-lane {
-  display: inline-flex;
+.action-bar__lane {
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
-  height: 40px;                /* matches typical footer chip height */
+  justify-content: center;
+  gap: clamp(6px, 1.8vw, 14px);
+  pointer-events: auto; /* ...but its children do */
 }
 
 /* Reserve space for the reset icon button so layout doesn't jump */


### PR DESCRIPTION
## Summary
- add a reusable ActionBar layout component with pointer-event guard and responsive centering
- swap bespoke floating button containers on the PDDL editor, chat, and MiniZinc pages to use the shared bar
- refresh the theme styles to position the shared bar above the footer with wrapping support

## Testing
- npm run lint *(fails: existing lint violations across legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68d85471c2d0832fa8da631ac1bde86b