### PR TITLE
Keep regenerate button visible and disabled until ready

### DIFF
--- a/Pianista-frontend/src/pages/pddl-edit.tsx
+++ b/Pianista-frontend/src/pages/pddl-edit.tsx
@@ -110,6 +110,7 @@ export default function PddlEditPage() {
   } = useMermaidPreview({ domain, problem });
 
   const canGenerate = !!domain.trim() && !!problem.trim();
+  const canRegenerate = planPhase === "success";
 
   /* --------------------------------- UI ----------------------------------- */
 
@@ -187,18 +188,17 @@ export default function PddlEditPage() {
           )}
           {/* Reset button — now to the RIGHT of Generate; reserved width prevents shifting */}
           <div className="reset-slot">
-            {planPhase === "success" && (
-              <PillButton
-                onClick={handleRegenerate}
-                iconOnly
-                rightIcon={<Reload className="icon-accent"/>}
-                ariaLabel="Clear Plan"
-                style={{
-                    width: 30,
-                    height: 30,
-                }}
-              />
-            )}
+            <PillButton
+              onClick={canRegenerate ? handleRegenerate : undefined}
+              iconOnly
+              rightIcon={<Reload className="icon-accent" />}
+              ariaLabel="Clear Plan"
+              style={{
+                width: 30,
+                height: 30,
+              }}
+              disabled={!canRegenerate}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- derive a `canRegenerate` flag from the planning phase
- keep the regenerate pill button mounted while disabling it until regeneration is allowed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d85901d854832fa8a384101f0080a6