### PR TITLE
Anchor action bar to right

### DIFF
--- a/Pianista-frontend/src/app/styles/theme.css
+++ b/Pianista-frontend/src/app/styles/theme.css
@@ -373,17 +373,17 @@ section[data-busy-glow="true"] {
   box-shadow: 0 2px 12px var(--color-shadow);
 }
 /* Floating actions bar shared across pages */
+
 .action-bar {
   position: fixed;
-  left: 50%;
+  right: clamp(16px, 4vw, 48px);
   bottom: calc(56px + env(safe-area-inset-bottom));
-  transform: translateX(-50%);
   z-index: 11; /* above content; below modals */
-  width: min(100vw, 960px);
+  width: min(90vw, 480px);
   padding: 0 16px;
   pointer-events: none; /* so it doesn’t block page clicks... */
   display: flex;
-  justify-content: center;
+  justify-content: flex-end;
 }
 
 .action-bar__lane {
@@ -393,6 +393,10 @@ section[data-busy-glow="true"] {
   justify-content: center;
   gap: clamp(6px, 1.8vw, 14px);
   pointer-events: auto; /* ...but its children do */
+  background-color: var(--color-bg);
+  border-radius: 16px;
+  padding: 12px 16px;
+  box-shadow: 0 12px 32px color-mix(in srgb, var(--color-shadow) 70%, transparent);
 }
 
 /* Reserve space for the reset icon button so layout doesn't jump */


### PR DESCRIPTION
## Summary
- anchor the floating action bar against the right edge with a reduced width so it rides over the right half of the viewport
- give the action bar lane an opaque themed background, rounded corners, and shadow to keep actions readable during layout shifts

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d95e137290832f8e966f492f80b668