### PR TITLE
Replace PDDL editor logo with new chat button

### DIFF
--- a/Pianista-frontend/src/features/pddl/pages/PddlEditPage.tsx
+++ b/Pianista-frontend/src/features/pddl/pages/PddlEditPage.tsx
@@ -1,7 +1,6 @@
 // src/pages/pddl-edit.tsx
 import { useNavigate, useSearchParams } from "react-router-dom";
 
-import BrandLogo from "@/shared/components/VS_BrandButton";
 import PillButton from "@/shared/components/PillButton";
 import ModeSlider from "@/shared/components/Inputbox/Controls/ModeSlider";
 import MermaidPanel from "@/features/pddl/components/MermaidPanel";
@@ -12,6 +11,7 @@ import Spinner from "@/shared/components/icons/Spinner";
 import Brain from "@/shared/components/icons/Brain";
 import Check from "@/shared/components/icons/Check";
 import Reload from "@/shared/components/icons/Reload";
+import Plus from "@/shared/components/icons/Plus";
 import ActionBar from "@/shared/components/layout/ActionBar";
 
 import { useTwoModeAutoDetect, type TwoMode } from "@/features/pddl/hooks/useTwoModeAutoDetect";
@@ -132,9 +132,15 @@ export default function PddlEditPage() {
         paddingBottom: floatingControlsClearance,
       }}
     >
-      <BrandLogo />
-
       <ActionBar>
+        <PillButton
+          iconOnly
+          ariaLabel="Start a new chat"
+          title="Start a new chat"
+          onClick={() => navigate("/chat")}
+          leftIcon={<Plus className="icon-accent" />}
+        />
+
         {/* View toggle button */}
         {isMermaidOpen ? (
           <PillButton

--- a/Pianista-frontend/src/shared/components/PillButton.tsx
+++ b/Pianista-frontend/src/shared/components/PillButton.tsx
@@ -7,6 +7,8 @@ export type PillButtonProps = {
   label?: string;
   /** Accessible label (required when iconOnly = true) */
   ariaLabel?: string;
+  /** Native tooltip when hovering */
+  title?: string;
   to?: string;
   /** Optional icons */
   leftIcon?: React.ReactNode;
@@ -52,6 +54,7 @@ export default function PillButton({
   to,
   target,
   rel,
+  title,
   type = "button",
   className,
   style,
@@ -153,6 +156,7 @@ export default function PillButton({
         onClick={onClick as any}
         className={className}
         style={mergedStyle}
+        title={title}
         {...commonHandlers}
       >
         {content}
@@ -171,6 +175,7 @@ export default function PillButton({
         onClick={onClick as any}
         className={className}
         style={mergedStyle}
+        title={title}
         {...commonHandlers}
       >
         {content}
@@ -186,6 +191,7 @@ export default function PillButton({
       onClick={onClick as any}
       className={className}
       style={mergedStyle}
+      title={title}
       {...commonHandlers}
     >
       {content}

--- a/Pianista-frontend/src/shared/components/icons/Plus.tsx
+++ b/Pianista-frontend/src/shared/components/icons/Plus.tsx
@@ -1,0 +1,39 @@
+// src/shared/components/icons/Plus.tsx
+import * as React from "react";
+
+type PlusIconProps = {
+  size?: number;
+  strokeWidth?: number;
+  className?: string;
+  style?: React.CSSProperties;
+  title?: string;
+};
+
+export default function Plus({
+  size = 16,
+  strokeWidth = 1.8,
+  className,
+  style,
+  title = "Add",
+}: PlusIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label={title}
+      className={className}
+      style={style}
+    >
+      <title>{title}</title>
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- remove the VisionSpace brand button from the PDDL editor layout
- add an icon-only "+" pill in the action bar that navigates back to chat with a tooltip hint
- allow pill buttons to surface native tooltips and introduce a reusable Plus icon

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d963862bc0832f8fedc2f8b37ea468