### PR TITLE
feat: add app shell layout and integrate navigation

### DIFF
--- a/Pianista-frontend/src/app/App.tsx
+++ b/Pianista-frontend/src/app/App.tsx
@@ -1,29 +1,90 @@
 import { Navigate, Route, Routes } from "react-router-dom";
 import { Toaster } from "react-hot-toast";
+import type { SVGProps } from "react";
 
 import Backdrop from "@/app/BackDrop";
-import ThemeSwitcherFab from "@/shared/components/themeSwitcher";
-import PianistaFooter from "@/shared/components/footer";
 import HomePage from "@/features/home/pages/HomePage";
 import ChatPage from "@/features/chat/pages/ChatPage";
 import PddlEditPage from "@/features/pddl/pages/PddlEditPage";
 import PlanPage from "@/features/planning/pages/PlanPage";
 import MiniZincPage from "@/features/minizinc/pages/MiniZincPage";
+import AppShell, { type AppShellTab } from "@/shared/components/layout/AppShell";
+
+const tabs: AppShellTab[] = [
+  { to: "/home", label: "Home", icon: <HomeIcon /> },
+  { to: "/chat", label: "Chat", icon: <ChatIcon /> },
+  { to: "/pddl-edit", label: "PDDL", icon: <PencilIcon /> },
+  { to: "/plan", label: "Plans", icon: <TimelineIcon /> },
+  { to: "/minizinc", label: "MiniZinc", icon: <PuzzleIcon /> },
+];
+
+function HomeIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" {...props}>
+      <path
+        d="M4.5 10.5 12 4l7.5 6.5v8a1.5 1.5 0 0 1-1.5 1.5h-3a1.5 1.5 0 0 1-1.5-1.5v-4.5h-4.5V19a1.5 1.5 0 0 1-1.5 1.5h-3a1.5 1.5 0 0 1-1.5-1.5v-8.5Z"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ChatIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" {...props}>
+      <path
+        d="M5 5.5h14a1.5 1.5 0 0 1 1.5 1.5v7a1.5 1.5 0 0 1-1.5 1.5H9.8L5 19.5v-13a1.5 1.5 0 0 1 1.5-1.5Z"
+        strokeLinejoin="round"
+      />
+      <path d="M8 10h8M8 13h5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function PencilIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" {...props}>
+      <path d="M5 15.5 16.5 4 20 7.5 8.5 19H5v-3.5Z" strokeLinejoin="round" />
+      <path d="m14.5 6 3.5 3.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function TimelineIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" {...props}>
+      <path d="M4 6h16M4 12h10M4 18h7" strokeLinecap="round" />
+      <circle cx="18" cy="12" r="2" />
+      <circle cx="13" cy="18" r="2" />
+    </svg>
+  );
+}
+
+function PuzzleIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" {...props}>
+      <path
+        d="M8.5 3.5a2.5 2.5 0 0 1 5 0V5H16a1 1 0 0 1 1 1v2.5h1.5a2.5 2.5 0 1 1 0 5H17V16a1 1 0 0 1-1 1h-2.5v1.5a2.5 2.5 0 0 1-5 0V17H6a1 1 0 0 1-1-1v-2.5H3.5a2.5 2.5 0 1 1 0-5H5V6a1 1 0 0 1 1-1h2.5V3.5Z"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
 
 export default function App() {
   return (
     <>
       <Backdrop />
-      <Routes>
-        <Route path="/" element={<Navigate replace to="/home" />} />
-        <Route path="/home" element={<HomePage />} />
-        <Route path="/chat" element={<ChatPage />} />
-        <Route path="/pddl-edit" element={<PddlEditPage />} />
-        <Route path="/plan" element={<PlanPage />} />
-        <Route path="/minizinc" element={<MiniZincPage />} />
-      </Routes>
-      <ThemeSwitcherFab />
-      <PianistaFooter />
+      <AppShell tabs={tabs}>
+        <Routes>
+          <Route path="/" element={<Navigate replace to="/home" />} />
+          <Route path="/home" element={<HomePage />} />
+          <Route path="/chat" element={<ChatPage />} />
+          <Route path="/pddl-edit" element={<PddlEditPage />} />
+          <Route path="/plan" element={<PlanPage />} />
+          <Route path="/minizinc" element={<MiniZincPage />} />
+        </Routes>
+      </AppShell>
       <Toaster position="bottom-right" />
     </>
   );

--- a/Pianista-frontend/src/app/styles/theme.css
+++ b/Pianista-frontend/src/app/styles/theme.css
@@ -58,6 +58,260 @@ html, body {
   --color-surface-bridge: color-mix(in srgb, var(--color-bg) 85%, white 15%);
 }
 
+/* ===================== App Shell Layout ===================== */
+
+.app-shell {
+  --shell-pane-width: clamp(240px, 24vw, 300px);
+  --shell-pane-width-collapsed: 84px;
+  --shell-transition: 220ms cubic-bezier(.25,.8,.25,1);
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(var(--shell-pane-width-collapsed), var(--shell-pane-width)) 1fr;
+  min-height: 100vh;
+  background: var(--color-bg);
+  color: var(--color-text);
+  transition: grid-template-columns var(--shell-transition);
+}
+
+.app-shell.is-collapsed {
+  grid-template-columns: var(--shell-pane-width-collapsed) 1fr;
+}
+
+.app-shell__pane {
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 1.25rem;
+  height: 100vh;
+  padding: 1.25rem 1rem 1.5rem;
+  border-right: 1px solid var(--color-border-muted);
+  background: color-mix(in srgb, var(--color-bg) 90%, var(--color-surface));
+  box-shadow: 4px 0 18px color-mix(in srgb, var(--color-shadow) 30%, transparent);
+  overflow: hidden;
+  transition: width var(--shell-transition), padding var(--shell-transition);
+}
+
+.app-shell.is-collapsed .app-shell__pane {
+  padding-inline: 0.75rem;
+}
+
+.app-shell__brand-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.app-shell__brand-button {
+  position: relative !important;
+  top: auto !important;
+  left: auto !important;
+}
+
+.app-shell__collapse {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--color-border-muted) 60%, transparent);
+  background: color-mix(in srgb, var(--color-surface) 80%, transparent);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+.app-shell__collapse:hover {
+  background: color-mix(in srgb, var(--color-accent) 22%, transparent);
+}
+
+.app-shell__collapse:active {
+  transform: scale(.95);
+}
+
+.app-shell__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.app-shell__tab {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 1px solid transparent;
+  transition: color 150ms ease, background 150ms ease, border-color 150ms ease;
+}
+
+.app-shell__tab-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--color-surface) 80%, transparent);
+  color: var(--color-text-secondary);
+  transition: color 150ms ease, background 150ms ease, transform 180ms ease;
+}
+
+.app-shell__tab:hover {
+  color: var(--color-text);
+  border-color: color-mix(in srgb, var(--color-border-muted) 75%, transparent);
+  background: color-mix(in srgb, var(--color-surface) 70%, transparent);
+}
+
+.app-shell__tab:hover .app-shell__tab-icon {
+  background: color-mix(in srgb, var(--color-accent) 20%, transparent);
+  color: var(--color-text);
+}
+
+.app-shell__tab.is-active {
+  color: var(--color-text);
+  border-color: color-mix(in srgb, var(--color-accent) 40%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 28%, transparent);
+}
+
+.app-shell__tab.is-active .app-shell__tab-icon {
+  background: color-mix(in srgb, var(--color-accent) 30%, transparent);
+  color: #fff;
+}
+
+.app-shell__tab-label {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+.app-shell.is-collapsed .app-shell__tab-label,
+.app-shell.is-collapsed .app-shell__section-title,
+.app-shell.is-collapsed .app-shell__past-placeholder {
+  opacity: 0;
+  transform: translateX(-6px);
+  pointer-events: none;
+}
+
+.app-shell__section-title {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: color-mix(in srgb, var(--color-text-secondary) 85%, transparent);
+  transition: opacity 200ms ease;
+}
+
+.app-shell__past-chats {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 0.25rem 0.25rem;
+  border-top: 1px dashed color-mix(in srgb, var(--color-border-muted) 65%, transparent);
+}
+
+.app-shell__past-placeholder {
+  min-height: 72px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  border: 1px dashed color-mix(in srgb, var(--color-border-muted) 45%, transparent);
+  background: color-mix(in srgb, var(--color-surface) 60%, transparent);
+  color: color-mix(in srgb, var(--color-text-secondary) 85%, transparent);
+  font-size: 0.8rem;
+  text-align: center;
+  padding: 0.75rem;
+  transition: opacity 200ms ease;
+}
+
+.app-shell__pane-footer {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid color-mix(in srgb, var(--color-border-muted) 50%, transparent);
+}
+
+.app-shell__body {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--color-bg);
+}
+
+.app-shell__content {
+  flex: 1;
+  padding: clamp(1.2rem, 4vw, 2rem) clamp(1.5rem, 5vw, 3.5rem);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 2.5rem);
+}
+
+.app-shell__footer {
+  padding: 0 clamp(1.5rem, 5vw, 3.5rem) clamp(1rem, 3vw, 2.5rem);
+}
+
+@media (max-width: 900px) {
+  .app-shell {
+    grid-template-columns: var(--shell-pane-width-collapsed) 1fr;
+  }
+
+  .app-shell__pane {
+    padding-top: 1rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .app-shell {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .app-shell__pane {
+    position: static;
+    flex-direction: row;
+    align-items: center;
+    height: auto;
+    border-right: none;
+    border-bottom: 1px solid var(--color-border-muted);
+    padding: 0.75rem 1rem;
+    gap: 1rem;
+  }
+
+  .app-shell__nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .app-shell__tab {
+    flex: 0 1 auto;
+  }
+
+  .app-shell__body {
+    min-height: 0;
+  }
+
+  .app-shell__content {
+    padding: 1.25rem;
+  }
+
+  .app-shell__pane-footer,
+  .app-shell__past-chats {
+    display: none;
+  }
+}
+
 /* --- Outline: default looks hovered; hover/active become more solid --- */
 .btn--outline.is-hover-default {
   background: color-mix(in srgb, var(--color-accent) 15%, transparent);
@@ -372,6 +626,68 @@ section[data-busy-glow="true"] {
   backdrop-filter: blur(6px);
   box-shadow: 0 2px 12px var(--color-shadow);
 }
+
+.pianista-footer {
+  font-size: 12px;
+  font-family: monospace;
+  color: var(--color-text-secondary);
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.pianista-footer--floating {
+  position: fixed;
+  inset: auto 0 0;
+  width: 100%;
+  padding-bottom: 8px;
+  z-index: 10;
+}
+
+.pianista-footer--inline {
+  position: static;
+  width: 100%;
+  padding-bottom: 0;
+}
+
+.pianista-footer__inner {
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.pianista-footer__tooltip {
+  position: absolute;
+  right: 0;
+  bottom: 140%;
+  min-width: 260px;
+  max-width: 360px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: 0 4px 16px var(--color-shadow);
+  font-family: monospace;
+  font-size: 11px;
+  line-height: 1.35;
+  border: 1px solid color-mix(in srgb, var(--color-accent) 28%, transparent);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 120ms ease;
+  pointer-events: none;
+}
+
+.footer-status-chip:hover .pianista-footer__tooltip {
+  opacity: 1;
+  visibility: visible;
+}
+
+.footer-status-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
 /* Floating actions bar shared across pages */
 
 .action-bar {
@@ -399,6 +715,23 @@ section[data-busy-glow="true"] {
   box-shadow: 0 12px 32px color-mix(in srgb, var(--color-shadow) 70%, transparent);
 }
 
+.app-shell .action-bar {
+  position: static;
+  right: auto;
+  bottom: auto;
+  width: 100%;
+  padding: 0;
+  margin-top: clamp(1rem, 3vw, 1.75rem);
+  pointer-events: auto;
+}
+
+.app-shell .action-bar__lane {
+  justify-content: flex-end;
+  background-color: color-mix(in srgb, var(--color-surface) 90%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border-muted) 65%, transparent);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--color-shadow) 45%, transparent);
+}
+
 /* Reserve space for the reset icon button so layout doesn't jump */
 .reset-slot {
   width: 44px;            /* tweak if your icon PillButton is wider/narrower */
@@ -416,6 +749,155 @@ section[data-busy-glow="true"] {
 }
 
 /* Reusable glow driven by --color-accent */
+.theme-switcher {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 0.7rem;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+
+.theme-switcher__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border-muted);
+  background: var(--color-surface);
+  box-shadow: 0 4px 12px var(--color-shadow);
+  cursor: pointer;
+  transition: transform .15s ease, box-shadow .2s ease, background 160ms ease;
+  backdrop-filter: blur(6px);
+  outline: none;
+}
+
+.theme-switcher__trigger:active {
+  transform: scale(.94);
+}
+
+.theme-switcher__menu {
+  position: absolute;
+  inset: auto 0 calc(100% + 0.6rem) auto;
+  min-width: 260px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 35%, var(--color-border-muted));
+  border-radius: 12px;
+  box-shadow: 0 14px 42px var(--color-shadow);
+  padding: 0.5rem;
+  opacity: 0;
+  transform: translateY(8px) scale(0.98);
+  transform-origin: bottom right;
+  transition: opacity 140ms ease, transform 180ms cubic-bezier(.2,.8,.2,1);
+  pointer-events: none;
+  backdrop-filter: blur(10px);
+  text-align: center;
+}
+
+.theme-switcher__menu-heading {
+  font-family: monospace;
+  font-size: .8rem;
+  opacity: 0.9;
+  padding: .25rem .5rem .35rem;
+}
+
+.theme-switcher[data-open="true"] .theme-switcher__menu {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.theme-switcher--pane {
+  position: relative;
+  right: auto;
+  bottom: auto;
+  width: 100%;
+  align-items: stretch;
+}
+
+.theme-switcher--pane .theme-switcher__trigger {
+  width: 100%;
+  height: auto;
+  padding: 0.65rem 0.85rem;
+  border-radius: 12px;
+  justify-content: space-between;
+  font-family: monospace;
+  font-size: 0.9rem;
+}
+
+.theme-switcher--pane .theme-switcher__menu {
+  inset: calc(100% + 0.65rem) 0 auto auto;
+  transform-origin: top right;
+}
+
+.theme-switcher__icon {
+  display: block;
+  user-select: none;
+}
+
+.theme-switcher__trigger-label {
+  font-weight: 700;
+}
+
+.theme-switcher__chevron {
+  font-size: 0.8rem;
+}
+
+.theme-switcher__option {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-family: monospace;
+  transition: background .15s ease, border-color .15s ease, transform .05s ease;
+  outline: none;
+}
+
+.theme-switcher__option:hover {
+  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+}
+
+.theme-switcher__option.is-active {
+  border-color: color-mix(in srgb, var(--color-accent) 55%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 22%, transparent);
+}
+
+.theme-switcher__option-text {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+}
+
+.theme-switcher__option-label {
+  font-weight: 800;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+}
+
+.theme-switcher__option-hint {
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
+.theme-switcher__option-check {
+  font-size: 1rem;
+  opacity: 0.9;
+}
+
 @keyframes glowPulse {
   0%   { box-shadow: 0 0 0 0   var(--glow-color, color-mix(in srgb, var(--color-accent) 36%, transparent)); }
   50%  { box-shadow: 0 0 0 6px var(--glow-soft,  color-mix(in srgb, var(--color-accent) 18%, transparent)); }

--- a/Pianista-frontend/src/features/chat/pages/ChatPage.tsx
+++ b/Pianista-frontend/src/features/chat/pages/ChatPage.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useTheme } from "@/app/providers/ThemeProvider";
 
-import BrandLogo from "@/shared/components/VS_BrandButton";
 import Textarea from "@/shared/components/Inputbox/TextArea";
 import ModeSlider from "@/shared/components/Inputbox/Controls/ModeSlider";
 import PillButton from "@/shared/components/PillButton";
@@ -22,7 +21,6 @@ import type { Mode } from "@/features/chat/hooks/useChatComposer";
 const ChatPage: React.FC = () => {
   const { name } = useTheme();
   const pianistaLogo = name === "light" ? logoLightBg : logoDarkBg;
-  const SHIFT_UP = "-10vh";
 
   // 1) Composer first — we need `text` for auto-detect
   const { text, setText, resetIfCleared, submit, status, statusHint } = useChatComposer();
@@ -53,10 +51,23 @@ const ChatPage: React.FC = () => {
     <main
       role="main"
       aria-label="Chat"
-      style={{ position: "absolute", inset: 0, display: "grid", placeItems: "center", textAlign: "center", zIndex: 5, padding: "1rem" }}
+      style={{
+        width: "100%",
+        minHeight: "100%",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        padding: "2rem 1rem",
+      }}
     >
-      <BrandLogo />
-      <div style={{ display: "grid", justifyItems: "center", gap: "1rem", width: "min(900px, 92vw)", transform: `translateY(${SHIFT_UP})` }}>
+      <div
+        style={{
+          display: "grid",
+          justifyItems: "center",
+          gap: "1.25rem",
+          width: "min(920px, 96vw)",
+        }}
+      >
         <img
           src={pianistaLogo}
           alt="Pianista logo"
@@ -64,7 +75,7 @@ const ChatPage: React.FC = () => {
           style={{ width: "clamp(160px, 28vw, 280px)", height: "auto", userSelect: "none", filter: "drop-shadow(0 3px 10px var(--color-shadow))" }}
         />
 
-        <div style={{ position: "relative", width: "42vw", maxWidth: 900 }}>
+        <div style={{ position: "relative", width: "min(640px, 90vw)", maxWidth: 900 }}>
           <Textarea
             ref={textareaRef as any}
             value={text}
@@ -95,7 +106,16 @@ const ChatPage: React.FC = () => {
           )}
         </div>
 
-        <div style={{ width: "42vw", maxWidth: 900, display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 8 }}>
+        <div
+          style={{
+            width: "min(640px, 90vw)",
+            maxWidth: 900,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "flex-end",
+            gap: 8,
+          }}
+        >
           <ModeSlider value={mode} onChange={setManual} size="xs" />
           <PillButton iconOnly ariaLabel="Send" onClick={() => submit(mode as Mode)} leftIcon={<ArrowUp />} />
         </div>

--- a/Pianista-frontend/src/features/home/pages/HomePage.tsx
+++ b/Pianista-frontend/src/features/home/pages/HomePage.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import { useTheme } from "@/app/providers/ThemeProvider";
 
-import PillButton from "@/shared/components/PillButton";
-import BrandLogo from "@/shared/components/VS_BrandButton";
-
 import logoLightBg from "@/assets/pianista_logo_black.png";
 import logoDarkBg from "@/assets/pianista_logo_white.png";
+
+import PillButton from "@/shared/components/PillButton";
 
 const HomePage: React.FC = () => {
   const { name } = useTheme();
@@ -16,23 +15,22 @@ const HomePage: React.FC = () => {
       role="main"
       aria-label="Pianista"
       style={{
-        position: "absolute",
-        inset: 0,
-        display: "grid",
-        placeItems: "center",
+        width: "100%",
+        minHeight: "100%",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        padding: "2rem 1rem",
         textAlign: "center",
-        zIndex: 5,
-        padding: "1rem",
       }}
     >
-      <BrandLogo />
       <div
         style={{
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
-          gap: "1.25rem",
-          transform: "translateY(-8vh)",
+          gap: "1.5rem",
+          maxWidth: "min(720px, 90vw)",
         }}
       >
         <img

--- a/Pianista-frontend/src/features/minizinc/pages/MiniZincPage.tsx
+++ b/Pianista-frontend/src/features/minizinc/pages/MiniZincPage.tsx
@@ -1,6 +1,5 @@
 // src/pages/minizinc.tsx
 import React from "react";
-import BrandLogo from "@/shared/components/VS_BrandButton";
 import Textarea, { type TextAreaStatus } from "@/shared/components/Inputbox/TextArea";
 import PillButton from "@/shared/components/PillButton";
 import { generateSolution } from "@/api/pianista/generateSolution";
@@ -147,26 +146,19 @@ while (attempt < maxPolls && aliveRef.current) {
       role="main"
       aria-label="MiniZinc"
       style={{
-        position: "absolute",
-        inset: 0,
-        display: "grid",
-        placeItems: "center",
-        textAlign: "center",
-        zIndex: 5,
-        padding: "1rem",
-        background: "var(--color-bg)",
-        color: "var(--color-text)",
+        width: "100%",
+        minHeight: "100%",
+        display: "flex",
+        justifyContent: "center",
+        padding: "2rem 1.25rem",
       }}
     >
-      <BrandLogo />
-
       <div
         style={{
           display: "grid",
           justifyItems: "center",
-          gap: "1rem",
-          width: "min(1100px, 96vw)",
-          transform: "translateY(-8vh)",
+          gap: "1.25rem",
+          width: "min(1100px, 98vw)",
         }}
       >
         <h1 style={{ marginBottom: 8  }}>MiniZinc</h1>

--- a/Pianista-frontend/src/features/pddl/pages/PddlEditPage.tsx
+++ b/Pianista-frontend/src/features/pddl/pages/PddlEditPage.tsx
@@ -1,7 +1,6 @@
 // src/pages/pddl-edit.tsx
 import { useNavigate, useSearchParams } from "react-router-dom";
 
-import BrandLogo from "@/shared/components/VS_BrandButton";
 import PillButton from "@/shared/components/PillButton";
 import ModeSlider from "@/shared/components/Inputbox/Controls/ModeSlider";
 import MermaidPanel from "@/features/pddl/components/MermaidPanel";
@@ -112,8 +111,6 @@ export default function PddlEditPage() {
 
   const canGenerate = !!domain.trim() && !!problem.trim();
   const canRegenerate = planPhase === "success";
-  const floatingControlsClearance =
-  "calc(env(safe-area-inset-bottom) + 56px + clamp(24px, 10vh, 40px))";
   /* --------------------------------- UI ----------------------------------- */
 
   return (
@@ -121,19 +118,13 @@ export default function PddlEditPage() {
       role="main"
       aria-label="PDDL edit"
       style={{
-        position: "absolute",
-        inset: 0,
-        overflow: "auto",
-        display: "grid",
-        placeItems: "center",
-        background: "var(--color-bg)",
-        color: "var(--color-text)",
-        padding: "1rem",
-        paddingBottom: floatingControlsClearance,
+        width: "100%",
+        minHeight: "100%",
+        display: "flex",
+        justifyContent: "center",
+        padding: "2rem 1.25rem",
       }}
     >
-      <BrandLogo />
-
       <ActionBar>
         {/* View toggle button */}
         {isMermaidOpen ? (
@@ -227,7 +218,13 @@ export default function PddlEditPage() {
       </style>
 
       {/* Content */}
-      <div style={{ display: "grid", gap: "1rem", width: "min(1160px, 92vw)" }}>
+      <div
+        style={{
+          display: "grid",
+          gap: "1.25rem",
+          width: "min(1160px, 96vw)",
+        }}
+      >
         {/* Mermaid panel */}
         {isMermaidOpen && (
           <MermaidPanel
@@ -265,7 +262,14 @@ export default function PddlEditPage() {
         )}
 
         {/* Editors row */}
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, alignItems: "start" }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 16,
+            alignItems: "start",
+          }}
+        >
           <EditorPanel<DomainEditMode>
             title="Domain"
             accentColor="var(--color-accent)"
@@ -359,8 +363,6 @@ export default function PddlEditPage() {
           />
         </div>
 
-        {/* Spacer so content never hides behind the fixed footer/actions */}
-        <div aria-hidden style={{ height: floatingControlsClearance }} />
       </div>
     </main>
   );

--- a/Pianista-frontend/src/features/planning/pages/PlanPage.tsx
+++ b/Pianista-frontend/src/features/planning/pages/PlanPage.tsx
@@ -34,14 +34,11 @@ export default function PlanPage() {
       role="main"
       aria-label="Plan viewer"
       style={{
-        position: "absolute",
-        inset: 0,
-        overflow: "hidden",
-        display: "grid",
-        placeItems: "center",
-        background: "var(--color-bg)",
-        color: "var(--color-text)",
-        padding: "12px 12px 84px 12px", // extra bottom padding for fixed footer
+        width: "100%",
+        minHeight: "100%",
+        display: "flex",
+        justifyContent: "center",
+        padding: "2rem 1.25rem",
       }}
     >
       <style>{`
@@ -52,7 +49,13 @@ export default function PlanPage() {
       `}</style>
 
       {/* Content (wider & taller than before) */}
-      <div style={{ display: "grid", gap: "12px", width: "min(1400px, 96vw)" }}>
+      <div
+        style={{
+          display: "grid",
+          gap: "1.25rem",
+          width: "min(1400px, 98vw)",
+        }}
+      >
         {/* Plan Container */}
         <section
           style={{

--- a/Pianista-frontend/src/shared/components/footer.tsx
+++ b/Pianista-frontend/src/shared/components/footer.tsx
@@ -5,7 +5,16 @@ import { pingPlanner } from "@/api/pianista/health";
 
 type UiStatus = "checking" | "ok" | "down";
 
-const PianistaFooter: React.FC = () => {
+type PianistaFooterProps = {
+  variant?: "floating" | "inline";
+  className?: string;
+};
+
+function cx(...parts: Array<string | undefined | false | null>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+const PianistaFooter: React.FC<PianistaFooterProps> = ({ variant = "floating", className }) => {
   useTheme(); // ensures data-theme gets applied
 
   const [ui, setUi] = React.useState<UiStatus>("checking");
@@ -30,7 +39,7 @@ const PianistaFooter: React.FC = () => {
   }, []);
 
   React.useEffect(() => {
-    check();                   // initial ping
+    check(); // initial ping
     const id = setInterval(check, 1000000000); // ping every 60s
     return () => clearInterval(id);
   }, [check]);
@@ -42,55 +51,23 @@ const PianistaFooter: React.FC = () => {
       ? "var(--color-danger, #dc2626)"
       : "var(--color-warning, #f59e0b)";
 
-  // (used only for a11y)
-  const a11yLabel =
-    ui === "ok" ? "Online" : ui === "down" ? "Offline" : "Checking";
+  const a11yLabel = ui === "ok" ? "Online" : ui === "down" ? "Offline" : "Checking";
 
   return (
     <footer
-      style={{
-        position: "fixed",
-        bottom: 0,
-        left: 0,
-        right: 0,
-        width: "100%",
-        textAlign: "center",
-        fontSize: "12px",
-        fontFamily: "monospace",
-        paddingBottom: "8px",
-        pointerEvents: "none",
-        zIndex: 10,
-      }}
+      className={cx(
+        "pianista-footer",
+        variant === "floating" ? "pianista-footer--floating" : "pianista-footer--inline",
+        className,
+      )}
     >
-      <div
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: "10px",
-          padding: "4px 16px",
-          borderRadius: "8px",
-          border:
-            "1px solid color-mix(in srgb, var(--color-accent) 20%, transparent)",
-          background:
-            "color-mix(in srgb, var(--color-bg) 20%, transparent)",
-          backdropFilter: "blur(6px)",
-          boxShadow: "0 2px 12px var(--color-shadow)",
-          color: "var(--color-text-secondary)",
-          pointerEvents: "auto",
-        }}
-      >
+      <div className="footer-chip pianista-footer__inner">
         <span>© 2025</span>
         <span style={{ color: "var(--color-text)" }}>VisionSpace™</span>
         <span>· All rights reserved</span>
-
-        {/* spacer dot before chip */}
         <span aria-hidden>·</span>
 
-        {/* API status chip (right-aligned end of row) */}
-        <div
-          className="footer-status-chip"
-          style={{ position: "relative", display: "inline-flex", alignItems: "center" }}
-        >
+        <div className="footer-status-chip">
           <button
             onClick={check}
             title="Click to recheck API status"
@@ -118,35 +95,9 @@ const PianistaFooter: React.FC = () => {
                     : "none",
               }}
             />
-            {/* keep only the short label */}
             <span style={{ color: "var(--color-text)" }}>API</span>
 
-            {/* Hover hint (tooltip) */}
-            <div
-              className="footer-status-tooltip"
-              role="status"
-              aria-live="polite"
-              style={{
-                position: "absolute",
-                right: 0,
-                bottom: "140%",
-                minWidth: 260,
-                maxWidth: 360,
-                padding: "8px 10px",
-                borderRadius: 8,
-                border: `1px solid ${color}`,
-                background: "var(--color-surface)",
-                color: "var(--color-text)",
-                boxShadow: "0 4px 16px var(--color-shadow)",
-                fontFamily: "monospace",
-                fontSize: "11px",
-                lineHeight: 1.35,
-                pointerEvents: "none",
-                opacity: 0,
-                visibility: "hidden",
-                transition: "opacity 120ms ease",
-              }}
-            >
+            <div className="pianista-footer__tooltip" role="status" aria-live="polite">
               <div style={{ marginBottom: 4, opacity: 0.9 }}>
                 {hint || "Planner gateway reachable."}
               </div>
@@ -156,16 +107,6 @@ const PianistaFooter: React.FC = () => {
             </div>
           </button>
         </div>
-
-        {/* tooltip hover CSS */}
-        <style>
-          {`
-            .footer-status-chip:hover .footer-status-tooltip {
-              opacity: 1;
-              visibility: visible;
-            }
-          `}
-        </style>
       </div>
     </footer>
   );

--- a/Pianista-frontend/src/shared/components/layout/AppShell.tsx
+++ b/Pianista-frontend/src/shared/components/layout/AppShell.tsx
@@ -1,0 +1,88 @@
+import { useState, type PropsWithChildren, type ReactNode } from "react";
+import { NavLink } from "react-router-dom";
+
+import BrandLogo from "@/shared/components/VS_BrandButton";
+import ThemeSwitcherFab from "@/shared/components/themeSwitcher";
+import PianistaFooter from "@/shared/components/footer";
+
+export type AppShellTab = {
+  to: string;
+  label: string;
+  icon: ReactNode;
+};
+
+export type AppShellProps = PropsWithChildren<{
+  tabs: AppShellTab[];
+  pastChatsSlot?: ReactNode;
+  footerSlot?: ReactNode;
+}>;
+
+function cx(...parts: Array<string | undefined | false | null>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+export default function AppShell({
+  tabs,
+  children,
+  pastChatsSlot,
+  footerSlot,
+}: AppShellProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div className={cx("app-shell", collapsed && "is-collapsed")}>
+      <aside className="app-shell__pane" aria-label="Primary navigation">
+        <div className="app-shell__brand-row">
+          <BrandLogo size={72} className="app-shell__brand-button" />
+          <button
+            type="button"
+            aria-label={collapsed ? "Expand navigation" : "Collapse navigation"}
+            aria-expanded={!collapsed}
+            className="app-shell__collapse"
+            onClick={() => setCollapsed((v) => !v)}
+          >
+            <span aria-hidden>{collapsed ? "⟩" : "⟨"}</span>
+          </button>
+        </div>
+
+        <nav className="app-shell__nav">
+          {tabs.map((tab) => (
+            <NavLink
+              key={tab.to}
+              to={tab.to}
+              className={({ isActive }) =>
+                cx("app-shell__tab", isActive && "is-active")
+              }
+              title={tab.label}
+            >
+              <span className="app-shell__tab-icon" aria-hidden>
+                {tab.icon}
+              </span>
+              <span className="app-shell__tab-label">{tab.label}</span>
+            </NavLink>
+          ))}
+        </nav>
+
+        <div className="app-shell__past-chats">
+          <span className="app-shell__section-title">Past Chats</span>
+          {pastChatsSlot ?? (
+            <div className="app-shell__past-placeholder" aria-hidden>
+              Conversation history will live here soon.
+            </div>
+          )}
+        </div>
+
+        <div className="app-shell__pane-footer">
+          <ThemeSwitcherFab variant="pane" />
+        </div>
+      </aside>
+
+      <div className="app-shell__body">
+        <main className="app-shell__content">{children}</main>
+        <div className="app-shell__footer">
+          {footerSlot ?? <PianistaFooter variant="inline" />}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `AppShell` with collapsible navigation, theme switcher slot, and footer integration for all routed pages
- expand the theme stylesheet with shell, navigation tab, footer, and pane-based theme switcher styles while aligning the action bar with the new layout
- wrap routes in the shell and refactor feature pages to fill the content area instead of relying on absolute positioning

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9680a0214832f9463bb79ac19c557