### PR TITLE
Adjust Back to Chat positioning for narrow screens

### DIFF
--- a/Pianista-frontend/src/app/styles/theme.css
+++ b/Pianista-frontend/src/app/styles/theme.css
@@ -411,6 +411,20 @@ section[data-busy-glow="true"] {
   .reset-slot { width: 40px; flex-basis: 40px; }
 }
 
+.back-to-chat-wrapper {
+  position: fixed;
+  left: clamp(16px, 4vw, 48px);
+  bottom: calc(env(safe-area-inset-bottom) + 16px);
+  z-index: 10;
+}
+
+@media (max-width: 420px) {
+  .back-to-chat-wrapper {
+    bottom: calc(env(safe-area-inset-bottom) + 108px);
+    left: clamp(12px, 6vw, 32px);
+  }
+}
+
 .icon-accent {
   color: var(--color-accent);
 }

--- a/Pianista-frontend/src/features/pddl/pages/PddlEditPage.tsx
+++ b/Pianista-frontend/src/features/pddl/pages/PddlEditPage.tsx
@@ -206,14 +206,7 @@ export default function PddlEditPage() {
 
       </ActionBar>
 
-      <div
-        style={{
-          position: "fixed",
-          left: "clamp(16px, 4vw, 48px)",
-          bottom: "calc(env(safe-area-inset-bottom) + 16px)",
-          zIndex: 10,
-        }}
-      >
+      <div className="back-to-chat-wrapper">
         <PillButton
           to="/chat"
           label="Back to Chat"


### PR DESCRIPTION
## Summary
- add a dedicated wrapper class for the Back to Chat button
- style the Back to Chat wrapper for both default and small viewports so it clears the floating ActionBar

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173


------
https://chatgpt.com/codex/tasks/task_e_68d973453cf4832fb5a8a25a1d83945f