### PR TITLE
Conditionally hide footer on PDDL editor route

### DIFF
--- a/Pianista-frontend/src/app/App.tsx
+++ b/Pianista-frontend/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { Toaster } from "react-hot-toast";
 
 import Backdrop from "@/app/BackDrop";
@@ -11,6 +11,8 @@ import PlanPage from "@/features/planning/pages/PlanPage";
 import MiniZincPage from "@/features/minizinc/pages/MiniZincPage";
 
 export default function App() {
+  const { pathname } = useLocation();
+
   return (
     <>
       <Backdrop />
@@ -23,7 +25,7 @@ export default function App() {
         <Route path="/minizinc" element={<MiniZincPage />} />
       </Routes>
       <ThemeSwitcherFab />
-      <PianistaFooter />
+      {!pathname.startsWith("/pddl-edit") && <PianistaFooter />}
       <Toaster position="bottom-right" />
     </>
   );


### PR DESCRIPTION
## Summary
- read the current location pathname in App using useLocation
- render PianistaFooter only when the path does not start with /pddl-edit

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d9774fb314832fb91d1639a00b1665