### PR TITLE
Move PDDL edit back button into action bar

### DIFF
--- a/Pianista-frontend/src/features/pddl/pages/PddlEditPage.tsx
+++ b/Pianista-frontend/src/features/pddl/pages/PddlEditPage.tsx
@@ -132,6 +132,12 @@ export default function PddlEditPage() {
       }}
     >
       <ActionBar>
+        <PillButton
+          to="/chat"
+          label="Back to Chat"
+          ariaLabel="Back to Chat"
+          leftIcon={<span aria-hidden>←</span>}
+        />
         {/* View toggle button */}
         {isMermaidOpen ? (
           <PillButton
@@ -205,24 +211,6 @@ export default function PddlEditPage() {
         </div>
 
       </ActionBar>
-
-      <div
-        style={{
-          position: "fixed",
-          left: "clamp(16px, 4vw, 48px)",
-          bottom: "calc(env(safe-area-inset-bottom) + 55px)",
-          zIndex: 10,
-        }}
-      >
-        <PillButton
-          to="/chat"
-          label="Back to Chat"
-          ariaLabel="Back to Chat"
-          leftIcon="←"
-        />
-      </div>
-
-
 
       {/* Glow CSS for plan button cluster */}
       <style>


### PR DESCRIPTION
## Summary
- add the Back to Chat pill button to the top action bar in the PDDL editor
- remove the redundant fixed-position button block at the bottom of the page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97ae7f15c832f9b549b7f86ce8123