### PR TITLE
Center the PDDL action bar

### DIFF
--- a/Pianista-frontend/src/features/pddl/pages/PddlEditPage.tsx
+++ b/Pianista-frontend/src/features/pddl/pages/PddlEditPage.tsx
@@ -131,7 +131,16 @@ export default function PddlEditPage() {
         paddingBottom: floatingControlsClearance,
       }}
     >
-      <ActionBar>
+      <ActionBar
+        style={{
+          left: 0,
+          right: 0,
+          margin: "0 auto",
+          justifyContent: "center",
+          width: "min(90vw, 480px)",
+        }}
+        laneStyle={{ margin: "0 auto" }}
+      >
         <PillButton
           to="/chat"
           label="Back to Chat"


### PR DESCRIPTION
## Summary
- center the PDDL edit page action bar container and lane so controls align in the middle of the viewport

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d97bca73f8832fb09f487bee0ee105